### PR TITLE
Removed Duplicate Definition in ELNXRayDiffraction

### DIFF
--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -426,31 +426,9 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData):
     measurement_identifiers = SubSection(
         section_def=ReadableIdentifiers,
     )
-    diffraction_method_name = Quantity(  # TODO: Change to m_copy() when https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/issues/1680 is solved
-        type=MEnum(
-            [
-                "Powder X-ray Diffraction (PXRD)",
-                "Single Crystal X-ray Diffraction (SCXRD)",
-                "High-Resolution X-ray Diffraction (HRXRD)",
-                "Small-Angle X-ray Scattering (SAXS)",
-                "X-ray Reflectivity (XRR)",
-                "Grazing Incidence X-ray Diffraction (GIXRD)",
-            ]
-        ),
-        description='''
-        The diffraction method used to obtain the diffraction pattern.
-        | X-ray Diffraction Method                                   | Description                                                                                                                                                                                                 |
-        |------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-        | **Powder X-ray Diffraction (PXRD)**                        | The term "powder" refers more to the random orientation of small crystallites than to the physical form of the sample. Can be used with non-powder samples if they present random crystallite orientations. |
-        | **Single Crystal X-ray Diffraction (SCXRD)**               | Used for determining the atomic structure of a single crystal.                                                                                                                                              |
-        | **High-Resolution X-ray Diffraction (HRXRD)**              | A technique typically used for detailed characterization of epitaxial thin films using precise diffraction measurements.                                                                                    |
-        | **Small-Angle X-ray Scattering (SAXS)**                    | Used for studying nanostructures in the size range of 1-100 nm. Provides information on particle size, shape, and distribution.                                                                             |
-        | **X-ray Reflectivity (XRR)**                               | Used to study thin film layers, interfaces, and multilayers. Provides info on film thickness, density, and roughness.                                                                                       |
-        | **Grazing Incidence X-ray Diffraction (GIXRD)**            | Primarily used for the analysis of thin films with the incident beam at a fixed shallow angle.                                                                                                              |
-        ''',
-        a_eln=ELNAnnotation(
-            component=ELNComponentEnum.EnumEditQuantity,
-        )
+    diffraction_method_name = XRayDiffraction.diffraction_method_name.m_copy()
+    diffraction_method_name.m_annotations['eln'] = ELNAnnotation(
+        component=ELNComponentEnum.EnumEditQuantity,
     )
 
 


### PR DESCRIPTION
Replaced duplicate definition of `diffraction_method_name` with an `m_copy()` of the super property.

closes #7 