### PR TITLE
added nomad_plugin.yaml in parent folder

### DIFF
--- a/src/nomad_measurements/nomad_plugin.yaml
+++ b/src/nomad_measurements/nomad_plugin.yaml
@@ -1,0 +1,3 @@
+description: This is a plugin schema generated from a yaml schema.
+name: schemas/nomad_measurements
+plugin_type: schema

--- a/src/nomad_measurements/nomad_plugin.yaml
+++ b/src/nomad_measurements/nomad_plugin.yaml
@@ -1,3 +1,3 @@
-description: This is a plugin schema generated from a yaml schema.
+description: A NOMAD plugin containing base sections for measurements.
 name: schemas/nomad_measurements
 plugin_type: schema


### PR DESCRIPTION
when using the plugin without pip install, but only with the pzthonpath, a yaml file is needed also in the parent folder to exploit the classes defined in the init.py there