### PR TITLE
Update mainfile_mime_re regex pattern in nomad_plugin.yaml

### DIFF
--- a/src/nomad_measurements/xrd/nomad_plugin.yaml
+++ b/src/nomad_measurements/xrd/nomad_plugin.yaml
@@ -1,7 +1,7 @@
 description: This is a plugin schema generated from a yaml schema.
 name: parsers/xrd
 plugin_type: parser
-mainfile_mime_re: text/xml|application/zip
+mainfile_mime_re: text/.*|application/zip
 mainfile_name_re: ^.*\.xrdml$|^.*\.rasx$
 parser_class_name: nomad_measurements.xrd.XRDParser
 code_name: XRD Parser


### PR DESCRIPTION
This pull request updates the `mainfile_mime_re` regex pattern in the `nomad_plugin.yaml` file. The previous pattern `text/xml|application/zip` has been replaced with `text/.*|application/zip`. This change allows for a wider range of text mime types to be matched.