### PR TITLE
Create dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ git clone git@github.com:FAIRmat-NFDI/nomad-measurements.git
 cd nomad-measurements
 ```
 
-And install the package in editable mode:
+And install the package in editable mode with the development ('dev') dependencies:
 ```sh
-pip install -e .
+pip install -e .[dev]
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,12 @@ classifiers = [
 ]
 dependencies = [
     "nomad-lab>=1.2.1",
+    "xmltodict==0.13.0",
+]
+[project.optional-dependencies]
+dev = [
     "pytest",
     "structlog==22.3.0",
-    "xmltodict==0.13.0",
 ]
 
 [project.license]

--- a/src/nomad_measurements/__init__.py
+++ b/src/nomad_measurements/__init__.py
@@ -15,7 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from typing import (
+    TYPE_CHECKING
+)
 from nomad.metainfo.metainfo import (
     Category,
 )
@@ -28,9 +30,6 @@ from nomad.datamodel.metainfo.basesections import (
     Process,
     Measurement,
 )
-from structlog.stdlib import (
-    BoundLogger,
-)
 from nomad.metainfo import (
     Quantity,
     SubSection,
@@ -40,6 +39,10 @@ from nomad.datamodel.metainfo.annotations import (
     ELNComponentEnum,
 )
 
+if TYPE_CHECKING:
+    from structlog.stdlib import (
+        BoundLogger,
+    )
 
 class NOMADMeasurementsCategory(EntryDataCategory):
     '''

--- a/src/nomad_measurements/transmission/parser.py
+++ b/src/nomad_measurements/transmission/parser.py
@@ -15,10 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-from nomad.datamodel import EntryArchive
+from typing import (
+    TYPE_CHECKING
+)
 from nomad.metainfo import (
-    MSection,
     Quantity,
 )
 from nomad.parsing import MatchingParser
@@ -31,6 +31,11 @@ from nomad.datamodel.data import (
 
 from nomad_measurements.utils import create_archive
 from nomad_measurements.transmission import ELNTransmission
+
+if TYPE_CHECKING:
+    from nomad.datamodel.datamodel import (
+        EntryArchive,
+    )
 
 
 class TransmissionDataFile(EntryData):
@@ -49,7 +54,7 @@ class TransmissionParser(MatchingParser):
             code_name='XRD Parser',
         )
 
-    def parse(self, mainfile: str, archive: EntryArchive, logger) -> None:
+    def parse(self, mainfile: str, archive: 'EntryArchive', logger) -> None:
         data_file = mainfile.split('/')[-1]
         entry = ELNTransmission.m_from_dict(ELNTransmission.m_def.a_template)
         entry.data_file = data_file

--- a/src/nomad_measurements/transmission/schema.py
+++ b/src/nomad_measurements/transmission/schema.py
@@ -18,27 +18,18 @@
 import re
 import os
 import json
-
-import numpy as np
-
+from typing import (
+    TYPE_CHECKING
+)
 from nomad.datamodel.metainfo.basesections import (
     Measurement,
-    MeasurementResult,
-    CompositeSystemReference,
     ReadableIdentifiers,
-)
-from nomad.datamodel.metainfo.eln import (
-    NexusDataConverter
-)
-from structlog.stdlib import (
-    BoundLogger,
 )
 from nomad.metainfo import (
     Package,
     Quantity,
     Section,
     SubSection,
-    MEnum,
 )
 from nomad.datamodel.data import (
     ArchiveSection,
@@ -48,13 +39,18 @@ from nomad.datamodel.metainfo.annotations import (
     ELNAnnotation,
     ELNComponentEnum,
 )
-from nomad.units import (
-    ureg,
-)
 
 from nomad_measurements import NOMADMeasurementsCategory
 
-from pynxtools.dataconverter.convert import convert  # pylint: disable=import-error
+from pynxtools.dataconverter.convert import convert
+
+if TYPE_CHECKING:
+    from nomad.datamodel.datamodel import (
+        EntryArchive,
+    )
+    from structlog.stdlib import (
+        BoundLogger,
+    )
 
 
 m_package = Package(name='nomad-measurements Transmission')
@@ -99,7 +95,7 @@ class Transmission(Measurement):
         section_def=Operator,
     )
 
-    def normalize(self, archive, logger: BoundLogger) -> None:
+    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger') -> None:
         super(Transmission, self).normalize(archive, logger)
         raw_path = archive.m_context.raw_path()
         eln_filename = '_transmission_eln_temp.json'
@@ -147,7 +143,6 @@ class Transmission(Measurement):
             raise e
         else:
             logger.info('triggered processing', mainfile=output)
-
 
 
 class ELNTransmission(Transmission, EntryData):

--- a/src/nomad_measurements/xrd/IKZ.py
+++ b/src/nomad_measurements/xrd/IKZ.py
@@ -7,6 +7,9 @@
 '''
 
 from __future__ import print_function
+from typing import (
+    TYPE_CHECKING
+)
 import zipfile
 import sys
 import xml.etree.ElementTree as ET
@@ -14,9 +17,11 @@ import collections
 import numpy as np
 import time
 import xmltodict
-from structlog.stdlib import (
-    BoundLogger,
-)
+if TYPE_CHECKING:
+    from structlog.stdlib import (
+        BoundLogger,
+    )
+
 
 def try_scalar(val):
     try:
@@ -114,7 +119,7 @@ def parse_rasx_metadata(xml):
         if len(attrib) < len(axis.attrib):
             missing = set(axis.attrib).difference(set(attrib))
             for key in missing:
-                print("Warning: unknown axis attribute: %s"%k)
+                print("Warning: unknown axis attribute: %s"%key)
         axes[axis.attrib["Name"]] = Axis(**attrib)
 
 
@@ -221,7 +226,7 @@ class RASXfile(object):
 
         return output
 
-    def get_1d_scan(self, logger: BoundLogger=None):
+    def get_1d_scan(self, logger: 'BoundLogger'=None):
         '''
         Collect the values and units of intensity, two_theta, and axis positions. Adapts 
         the output if collected data has multiple/2d scans.
@@ -425,7 +430,7 @@ class BRMLfile(object):
                 if not self.motors[key].shape:
                     self.motors[key] = self.motors[key].item()
 
-    def get_1d_scan(self, logger: BoundLogger=None):
+    def get_1d_scan(self, logger: 'BoundLogger'=None):
         '''
         Collect the values and units of intensity, two_theta, and axis positions. Adapts
         the output if collected data has multiple/2d scans.

--- a/src/nomad_measurements/xrd/parser.py
+++ b/src/nomad_measurements/xrd/parser.py
@@ -15,8 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-from nomad.datamodel import EntryArchive
+from typing import (
+    TYPE_CHECKING
+)
 from nomad.metainfo import (
     Quantity,
 )
@@ -30,6 +31,11 @@ from nomad.datamodel.data import (
 
 from nomad_measurements.utils import create_archive
 from nomad_measurements.xrd import ELNXRayDiffraction
+
+if TYPE_CHECKING:
+    from nomad.datamodel.datamodel import (
+        EntryArchive,
+    )
 
 
 class XRDDataFile(EntryData):
@@ -54,7 +60,7 @@ class XRDParser(MatchingParser):
         )
 
     def parse(
-            self, mainfile: str, archive: EntryArchive, logger=None, child_archives=None
+            self, mainfile: str, archive: 'EntryArchive', logger=None, child_archives=None
         ) -> None:
         data_file = mainfile.split('/')[-1]
         entry = ELNXRayDiffraction.m_from_dict(ELNXRayDiffraction.m_def.a_template)

--- a/src/nomad_measurements/xrd/readers.py
+++ b/src/nomad_measurements/xrd/readers.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import xml.etree.ElementTree as ET
 from typing import (
     Dict,


### PR DESCRIPTION
This PR:
- Moves type checking imports to a `if TYPE_CHECKING:` clause
- Adds single quotes around all (non-native) type checking hints
- Creates `dev` dependencies in `pyproject.toml` and moves `structlog` and `pytest` there