### PR TITLE
Refactor file_name variable in XRDParser class

### DIFF
--- a/src/nomad_measurements/xrd/parser.py
+++ b/src/nomad_measurements/xrd/parser.py
@@ -65,6 +65,6 @@ class XRDParser(MatchingParser):
         data_file = mainfile.split('/')[-1]
         entry = ELNXRayDiffraction.m_from_dict(ELNXRayDiffraction.m_def.a_template)
         entry.data_file = data_file
-        file_name = f'{data_file[:-6]}.archive.json'
+        file_name = f'{"".join(data_file.split(".")[:-1])}.archive.json'
         archive.data = XRDDataFile(measurement=create_archive(entry,archive,file_name))
-        archive.metadata.entry_name = data_file[:-6] + ' data file'
+        archive.metadata.entry_name = "".join(data_file.split(".")[:-1]) + ' data file'

--- a/src/nomad_measurements/xrd/parser.py
+++ b/src/nomad_measurements/xrd/parser.py
@@ -67,4 +67,4 @@ class XRDParser(MatchingParser):
         entry.data_file = data_file
         file_name = f'{"".join(data_file.split(".")[:-1])}.archive.json'
         archive.data = XRDDataFile(measurement=create_archive(entry,archive,file_name))
-        archive.metadata.entry_name = "".join(data_file.split(".")[:-1]) + ' data file'
+        archive.metadata.entry_name = f'{data_file} data file'


### PR DESCRIPTION
The file_name is extracted from the data file name after leaving out the file format. For example, file_name for `XRD_mycompound.rasx` will be `XRD_mycompound`

Similar edits have been made for `archive.metadata.entry_name` 