### PR TITLE
Refactored to_pint_quantity function

### DIFF
--- a/src/nomad_measurements/utils.py
+++ b/src/nomad_measurements/utils.py
@@ -113,7 +113,8 @@ def merge_sections(
 
 def to_pint_quantity(value: Any=None, unit: str=None) -> Any:
     '''
-    Attempts to generate a pint quantity based on whether value or/and unit are available.
+    Attempts to generate a pint quantity.
+    In case the value is a string, it is returned as is.
 
     Args:
         value (Any): Value of the quantity.
@@ -122,6 +123,6 @@ def to_pint_quantity(value: Any=None, unit: str=None) -> Any:
     Returns:
         Any: Processed quantity with datatype depending on the value.
     '''
-    if not unit:
+    if isinstance(value, str):
         return value
     return value * ureg(unit)


### PR DESCRIPTION
With this modification, `to_pint_quantity` allows dimensionless values to be converted as pint Quantity. This is now possible with `nomad.units.ureg`. The function only checks if `value` is a string, in which case it does not generate a pint Quantity. 