### PR TITLE
86 improve xrd plots

### DIFF
--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -843,15 +843,18 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
         )
         xrd_settings.normalize(archive, logger)
 
-        sample = CompositeSystemReference(
-            lab_id=metadata_dict.get('sample_id', None),
-        )
-        sample.normalize(archive, logger)
+        samples = []
+        if metadata_dict.get('sample_id', None) is not None:
+            sample = CompositeSystemReference(
+                lab_id=metadata_dict['sample_id'],
+            )
+            sample.normalize(archive, logger)
+            samples.append(sample)
 
         xrd = ELNXRayDiffraction(
             results = [result],
             xrd_settings = xrd_settings,
-            samples = [sample],
+            samples = samples,
         )
         merge_sections(self, xrd, logger)
 

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -384,7 +384,11 @@ class XRDResult1D(XRDResult):
             y=y,
         )
         fig_line_linear.update_layout(
-            title='Intensity vs 2θ (linear scale)',
+            title={
+                'text': 'Intensity vs 2θ (linear scale)',
+                'x': 0.5,
+                'xanchor': 'center',
+            },
             xaxis_title='2θ (°)',
             yaxis_title='Intensity',
             xaxis=dict(
@@ -393,6 +397,9 @@ class XRDResult1D(XRDResult):
             yaxis=dict(
                 fixedrange=False,
             ),
+            template='plotly_white',
+            width=600,
+            height=600,
         )
         plots.append(
             PlotlyFigure(
@@ -408,7 +415,11 @@ class XRDResult1D(XRDResult):
             log_y=True,
         )
         fig_line_log.update_layout(
-            title='Intensity vs 2θ (log scale)',
+            title={
+                'text': 'Intensity vs 2θ (log scale)',
+                'x': 0.5,
+                'xanchor': 'center',
+            },
             xaxis_title='2θ (°)',
             yaxis_title='Intensity',
             xaxis=dict(
@@ -417,6 +428,9 @@ class XRDResult1D(XRDResult):
             yaxis=dict(
                 fixedrange=False,
             ),
+            template='plotly_white',
+            width=600,
+            height=600,
         )
         plots.append(
             PlotlyFigure(
@@ -535,7 +549,7 @@ class XRDResultRSM(XRDResult):
         )
         plots.append(
             PlotlyFigure(
-                label='RSM 2Theta-Omega',
+                label='RSM 2θ-ω',
                 index=1,
                 figure=fig_2theta_omega.to_plotly_json(),
             ),

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -556,8 +556,8 @@ class XRDResultRSM(XRDResult):
             )
             fig_q_vector.update_layout(
                 title='RSM plot: Intensity (log-scale) vs Q-vectors',
-                xaxis_title='Q_parallel (1/Å)',
-                yaxis_title='Q_perpendicular (1/Å)',
+                xaxis_title='<em>q<sub>&#x2016;</sub></em> (Å<sup>-1</sup>)', # q ‖
+                yaxis_title='<em>q<sub>&#x22A5;</sub></em> (Å<sup>-1</sup>)', # q ⊥
                 xaxis=dict(
                     autorange=False,
                     fixedrange=False,

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -382,15 +382,21 @@ class XRDResult1D(XRDResult):
         fig_line_linear = px.line(
             x=x,
             y=y,
-            labels={
-                'x': '2θ (°)',
-                'y': 'Intensity',
-            },
-            title='Intensity (linear scale)',
+        )
+        fig_line_linear.update_layout(
+            title='Intensity vs 2θ (linear scale)',
+            xaxis_title='2θ (°)',
+            yaxis_title='Intensity',
+            xaxis=dict(
+                fixedrange=False,
+            ),
+            yaxis=dict(
+                fixedrange=False,
+            ),
         )
         plots.append(
             PlotlyFigure(
-                label='Intensity vs 2Theta (Linear)',
+                label='Intensity (linear scale)',
                 index=1,
                 figure=fig_line_linear.to_plotly_json(),
             )
@@ -400,15 +406,21 @@ class XRDResult1D(XRDResult):
             x=x,
             y=y,
             log_y=True,
-            labels={
-                'x': '2θ (°)',
-                'y': 'Intensity',
-            },
-            title='Intensity (log scale)',
+        )
+        fig_line_log.update_layout(
+            title='Intensity vs 2θ (log scale)',
+            xaxis_title='2θ (°)',
+            yaxis_title='Intensity',
+            xaxis=dict(
+                fixedrange=False,
+            ),
+            yaxis=dict(
+                fixedrange=False,
+            ),
         )
         plots.append(
             PlotlyFigure(
-                label='Intensity vs 2Theta (Log)',
+                label='Intensity (log scale)',
                 index=0,
                 figure=fig_line_log.to_plotly_json(),
             )

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -397,12 +397,12 @@ class XRDResult1D(XRDResult):
         )
         fig_line_linear.update_layout(
             title={
-                'text': 'Intensity vs 2θ (linear scale)',
+                'text': '<i>Intensity</i> over 2<i>θ</i> (linear scale)',
                 'x': 0.5,
                 'xanchor': 'center',
             },
-            xaxis_title='2θ (°)',
-            yaxis_title='Intensity',
+            xaxis_title='2<i>θ</i> (°)',
+            yaxis_title='<i>Intensity</i>',
             xaxis=dict(
                 fixedrange=False,
             ),
@@ -415,7 +415,7 @@ class XRDResult1D(XRDResult):
         )
         plots.append(
             PlotlyFigure(
-                label='Intensity vs 2θ (linear scale)',
+                label='Intensity over 2θ (linear scale)',
                 index=1,
                 figure=fig_line_linear.to_plotly_json(),
             )
@@ -428,12 +428,12 @@ class XRDResult1D(XRDResult):
         )
         fig_line_log.update_layout(
             title={
-                'text': 'Intensity vs 2θ (log scale)',
+                'text': '<i>Intensity</i> over 2<i>θ</i> (log scale)',
                 'x': 0.5,
                 'xanchor': 'center',
             },
-            xaxis_title='2θ (°)',
-            yaxis_title='Intensity',
+            xaxis_title='2<i>θ</i> (°)',
+            yaxis_title='<i>Intensity</i>',
             xaxis=dict(
                 fixedrange=False,
             ),
@@ -446,7 +446,7 @@ class XRDResult1D(XRDResult):
         )
         plots.append(
             PlotlyFigure(
-                label='Intensity vs 2θ (log scale)',
+                label='Intensity over 2θ (log scale)',
                 index=0,
                 figure=fig_line_log.to_plotly_json(),
             )
@@ -463,12 +463,12 @@ class XRDResult1D(XRDResult):
         )
         fig_line_log.update_layout(
             title={
-                'text': 'Intensity vs <em>|q|</em> (log scale)',
+                'text': '<i>Intensity</i> over |<em>q</em>| (log scale)',
                 'x': 0.5,
                 'xanchor': 'center',
             },
-            xaxis_title='<em>|q|</em> (Å<sup>-1</sup>)',
-            yaxis_title='Intensity',
+            xaxis_title='|<em>q</em>| (Å<sup>-1</sup>)',
+            yaxis_title='<i>Intensity</i>',
             xaxis=dict(
                 fixedrange=False,
             ),
@@ -481,7 +481,7 @@ class XRDResult1D(XRDResult):
         )
         plots.append(
             PlotlyFigure(
-                label='Intensity vs q_norm (log scale)',
+                label='Intensity over q_norm (log scale)',
                 index=2,
                 figure=fig_line_log.to_plotly_json(),
             )
@@ -572,19 +572,19 @@ class XRDResultRSM(XRDResult):
             cmax=log_z.max(),
             colorbar={
                 'len': 0.9,
-                'title': '<em>log<sub>10</sub></em> Intensity<em></em>',
+                'title': 'log<sub>10</sub> <i>Intensity</i>',
                 'ticks': 'outside',
                 'tickformat': '5',
             },
         )
         fig_2theta_omega.update_layout(
             title={
-                    'text': 'Reciprocal Space Map over 2θ-ω',
+                    'text': 'Reciprocal Space Map over 2<i>θ</i>-<i>ω</i>',
                     'x': 0.5,
                     'xanchor': 'center',
                 },
-            xaxis_title='ω (°)',
-            yaxis_title='2θ (°)',
+            xaxis_title='<i>ω</i> (°)',
+            yaxis_title='2<i>θ</i> (°)',
             xaxis=dict(
                 autorange=False,
                 fixedrange=False,
@@ -637,7 +637,7 @@ class XRDResultRSM(XRDResult):
                 cmax=log_z_interpolated.max(),
                 colorbar={
                     'len': 0.9,
-                    'title': '<em>log<sub>10</sub></em> Intensity<em></em>',
+                    'title': 'log<sub>10</sub> <i>Intensity</i>',
                     'ticks': 'outside',
                     'tickformat': '5',
                 },
@@ -648,8 +648,8 @@ class XRDResultRSM(XRDResult):
                     'x': 0.5,
                     'xanchor': 'center',
                 },
-                xaxis_title='<em>q<sub>&#x2016;</sub></em> (Å<sup>-1</sup>)', # q ‖
-                yaxis_title='<em>q<sub>&#x22A5;</sub></em> (Å<sup>-1</sup>)', # q ⊥
+                xaxis_title='<i>q</i><sub>&#x2016;</sub> (Å<sup>-1</sup>)', # q ‖
+                yaxis_title='<i>q</i><sub>&#x22A5;</sub> (Å<sup>-1</sup>)', # q ⊥
                 xaxis=dict(
                     autorange=False,
                     fixedrange=False,
@@ -666,7 +666,7 @@ class XRDResultRSM(XRDResult):
             )
             plots.append(
                 PlotlyFigure(
-                    label='RSM Q-Vectors',
+                    label='RSM Q-vectors',
                     index=0,
                     figure=fig_q_vector.to_plotly_json(),
                 ),

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -645,9 +645,10 @@ class XRDResultRSM(XRDResult):
         )
         fig_2theta_omega.update_traces(
             hovertemplate=(
-                '<i>Intensity</i>: %{z:.2f}<br>'
+                '<i>Intensity</i>: 10<sup>%{z:.2f}</sup><br>'
                 '2<i>θ</i>: %{y}°<br>'
                 '<i>ω</i>: %{x}°'
+                '<extra></extra>'
             )
         )
         plot_json = fig_2theta_omega.to_plotly_json()
@@ -726,11 +727,12 @@ class XRDResultRSM(XRDResult):
             )
             fig_q_vector.update_traces(
                 hovertemplate=(
-                    '<i>Intensity</i>: %{z:.2f}<br>'
-                    '<i>q</i><sub>&#x22A5;</sub>: %{y}Å<sup>-1</sup><br>'
-                    '<i>q</i><sub>&#x2016;</sub>: %{x}Å<sup>-1</sup>'
-                    )
+                    '<i>Intensity</i>: 10<sup>%{z:.2f}</sup><br>'
+                    '<i>q</i><sub>&#x22A5;</sub>: %{y} Å<sup>-1</sup><br>'
+                    '<i>q</i><sub>&#x2016;</sub>: %{x} Å<sup>-1</sup>'
+                    '<extra></extra>'
                 )
+            )
             plot_json = fig_q_vector.to_plotly_json()
             plot_json['config'] = dict(
                 scrollZoom=False,

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -299,7 +299,7 @@ class XRDResult(MeasurementResult):
 
     m_def = Section()
 
-    index_array = Quantity(
+    array_index = Quantity(
         type=np.dtype(np.float64),
         shape=['*'],
         description=(
@@ -313,21 +313,21 @@ class XRDResult(MeasurementResult):
         shape=['*'],
         unit='dimensionless',
         description='The count at each 2-theta value, dimensionless',
-        a_plot={'x': 'index_array', 'y': 'intensity'},
+        a_plot={'x': 'array_index', 'y': 'intensity'},
     )
     two_theta = Quantity(
         type=np.dtype(np.float64),
         shape=['*'],
         unit='deg',
         description='The 2-theta range of the diffractogram',
-        a_plot={'x': 'index_array', 'y': 'two_theta'},
+        a_plot={'x': 'array_index', 'y': 'two_theta'},
     )
     q_norm = Quantity(
         type=np.dtype(np.float64),
         shape=['*'],
         unit='meter**(-1)',
         description='The norm of scattering vector *Q* of the diffractogram',
-        a_plot={'x': 'index_array', 'y': 'q_norm'},
+        a_plot={'x': 'array_index', 'y': 'q_norm'},
     )
     omega = Quantity(
         type=np.dtype(np.float64),

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -299,23 +299,35 @@ class XRDResult(MeasurementResult):
 
     m_def = Section()
 
+    index_array = Quantity(
+        type=np.dtype(np.float64),
+        shape=['*'],
+        description=(
+            'A placeholder for the indices of vectorial quantities. '
+            'Used as x-axis for plots within quantities.'
+        ),
+        a_display={'visible': False},
+    )
     intensity = Quantity(
         type=np.dtype(np.float64),
         shape=['*'],
         unit='dimensionless',
         description='The count at each 2-theta value, dimensionless',
+        a_plot={'x': 'index_array', 'y': 'intensity'},
     )
     two_theta = Quantity(
         type=np.dtype(np.float64),
         shape=['*'],
         unit='deg',
         description='The 2-theta range of the diffractogram',
+        a_plot={'x': 'index_array', 'y': 'two_theta'},
     )
     q_norm = Quantity(
         type=np.dtype(np.float64),
         shape=['*'],
         unit='meter**(-1)',
         description='The norm of scattering vector *Q* of the diffractogram',
+        a_plot={'x': 'index_array', 'y': 'q_norm'},
     )
     omega = Quantity(
         type=np.dtype(np.float64),

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -452,6 +452,11 @@ class XRDResult1D(XRDResult):
             logger (BoundLogger): A structlog logger.
         """
         super().normalize(archive, logger)
+        if self.name is None:
+            if self.scan_axis:
+                self.name = f'{self.scan_axis} Scan Result'
+            else:
+                self.name = 'XRD Scan Result'
         if self.source_peak_wavelength is not None:
             self.q_norm, self.two_theta = calculate_two_theta_or_q(
                 wavelength=self.source_peak_wavelength,
@@ -624,6 +629,8 @@ class XRDResultRSM(XRDResult):
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
         super().normalize(archive, logger)
+        if self.name is None:
+            self.name = 'RSM Scan Result'
         var_axis = 'omega'
         if self.source_peak_wavelength is not None:
             for var_axis in ['omega', 'chi', 'phi']:

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -488,6 +488,7 @@ class XRDResultRSM(XRDResult):
             return plots
 
         # Plot for 2theta-omega RSM
+        # Zero values in intensity become -inf in log scale and are not plotted
         x = self.omega.to('degree').magnitude
         y = self.two_theta.to('degree').magnitude
         z = self.intensity.magnitude
@@ -498,10 +499,24 @@ class XRDResultRSM(XRDResult):
             img=np.around(log_z, 3).T,
             x=np.around(x, 3),
             y=np.around(y, 3),
-            color_continuous_scale='inferno',
+        )
+        fig_2theta_omega.update_coloraxes(
+            colorscale='inferno',
+            cmin=np.nanmin(log_z[log_z != -np.inf]),
+            cmax=log_z.max(),
+            colorbar={
+                'len': 0.9,
+                'title': '<em>log<sub>10</sub></em> Intensity<em></em>',
+                'ticks': 'outside',
+                'tickformat': '5',
+            },
         )
         fig_2theta_omega.update_layout(
-            title='RSM plot: Intensity (log-scale) vs Axis position',
+            title={
+                    'text': 'Reciprocal Space Map over 2θ-ω',
+                    'x': 0.5,
+                    'xanchor': 'center',
+                },
             xaxis_title='ω (°)',
             yaxis_title='2θ (°)',
             xaxis=dict(
@@ -514,6 +529,7 @@ class XRDResultRSM(XRDResult):
                 fixedrange=False,
                 range=y_range,
             ),
+            template='plotly_white',
             width=600,
             height=600,
         )
@@ -548,14 +564,24 @@ class XRDResultRSM(XRDResult):
                 img=np.around(log_z_interpolated, 3),
                 x=np.around(x_regular, 3),
                 y=np.around(y_regular, 3),
-                color_continuous_scale='inferno',
-                range_color=[
-                    np.nanmin(log_z[log_z != -np.inf]),
-                    log_z_interpolated.max(),
-                ],
+            )
+            fig_q_vector.update_coloraxes(
+                colorscale='inferno',
+                cmin=np.nanmin(log_z[log_z != -np.inf]),
+                cmax=log_z_interpolated.max(),
+                colorbar={
+                    'len': 0.9,
+                    'title': '<em>log<sub>10</sub></em> Intensity<em></em>',
+                    'ticks': 'outside',
+                    'tickformat': '5',
+                },
             )
             fig_q_vector.update_layout(
-                title='RSM plot: Intensity (log-scale) vs Q-vectors',
+                title={
+                    'text': 'Reciprocal Space Map over Q-vectors',
+                    'x': 0.5,
+                    'xanchor': 'center',
+                },
                 xaxis_title='<em>q<sub>&#x2016;</sub></em> (Å<sup>-1</sup>)', # q ‖
                 yaxis_title='<em>q<sub>&#x22A5;</sub></em> (Å<sup>-1</sup>)', # q ⊥
                 xaxis=dict(
@@ -568,6 +594,7 @@ class XRDResultRSM(XRDResult):
                     fixedrange=False,
                     range=y_range,
                 ),
+                template='plotly_white',
                 width=600,
                 height=600,
             )

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -403,7 +403,7 @@ class XRDResult1D(XRDResult):
         )
         plots.append(
             PlotlyFigure(
-                label='Intensity (linear scale)',
+                label='Intensity vs 2θ (linear scale)',
                 index=1,
                 figure=fig_line_linear.to_plotly_json(),
             )
@@ -434,8 +434,43 @@ class XRDResult1D(XRDResult):
         )
         plots.append(
             PlotlyFigure(
-                label='Intensity (log scale)',
+                label='Intensity vs 2θ (log scale)',
                 index=0,
+                figure=fig_line_log.to_plotly_json(),
+            )
+        )
+
+        if self.q_norm is None:
+            return plots
+
+        x = self.q_norm.to('1/angstrom').magnitude
+        fig_line_log = px.line(
+            x=x,
+            y=y,
+            log_y=True,
+        )
+        fig_line_log.update_layout(
+            title={
+                'text': 'Intensity vs <em>|q|</em> (log scale)',
+                'x': 0.5,
+                'xanchor': 'center',
+            },
+            xaxis_title='<em>|q|</em> (Å<sup>-1</sup>)',
+            yaxis_title='Intensity',
+            xaxis=dict(
+                fixedrange=False,
+            ),
+            yaxis=dict(
+                fixedrange=False,
+            ),
+            template='plotly_white',
+            width=600,
+            height=600,
+        )
+        plots.append(
+            PlotlyFigure(
+                label='Intensity vs q_norm (log scale)',
+                index=2,
                 figure=fig_line_log.to_plotly_json(),
             )
         )

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -410,14 +410,26 @@ class XRDResult1D(XRDResult):
                 fixedrange=False,
             ),
             template='plotly_white',
+            hovermode='closest',
+            hoverlabel=dict(
+                bgcolor='white',
+            ),
+            dragmode='zoom',
             width=600,
             height=600,
+        )
+        fig_line_linear.update_traces(
+            hovertemplate='<i>Intensity</i>: %{y:.2f}<br>2<i>θ</i>: %{x}°',
+        )
+        plot_json = fig_line_linear.to_plotly_json()
+        plot_json['config'] = dict(
+            scrollZoom=False,
         )
         plots.append(
             PlotlyFigure(
                 label='Intensity over 2θ (linear scale)',
                 index=1,
-                figure=fig_line_linear.to_plotly_json(),
+                figure=plot_json,
             )
         )
 
@@ -441,14 +453,26 @@ class XRDResult1D(XRDResult):
                 fixedrange=False,
             ),
             template='plotly_white',
+            hovermode='closest',
+            hoverlabel=dict(
+                bgcolor='white',
+            ),
+            dragmode='zoom',
             width=600,
             height=600,
+        )
+        fig_line_log.update_traces(
+            hovertemplate='<i>Intensity</i>: %{y:.2f}<br>2<i>θ</i>: %{x}°',
+        )
+        plot_json = fig_line_log.to_plotly_json()
+        plot_json['config'] = dict(
+            scrollZoom=False,
         )
         plots.append(
             PlotlyFigure(
                 label='Intensity over 2θ (log scale)',
                 index=0,
-                figure=fig_line_log.to_plotly_json(),
+                figure=plot_json,
             )
         )
 
@@ -476,14 +500,29 @@ class XRDResult1D(XRDResult):
                 fixedrange=False,
             ),
             template='plotly_white',
+            hovermode='closest',
+            hoverlabel=dict(
+                bgcolor='white',
+            ),
+            dragmode='zoom',
             width=600,
             height=600,
+        )
+        fig_line_log.update_traces(
+            hovertemplate=(
+                '<i>Intensity</i>: %{y:.2f}<br>'
+                '|<em>q</em>|: %{x} Å<sup>-1</sup>'
+            ),
+        )
+        plot_json = fig_line_log.to_plotly_json()
+        plot_json['config'] = dict(
+            scrollZoom=False,
         )
         plots.append(
             PlotlyFigure(
                 label='Intensity over q_norm (log scale)',
                 index=2,
-                figure=fig_line_log.to_plotly_json(),
+                figure=plot_json,
             )
         )
 
@@ -596,14 +635,30 @@ class XRDResultRSM(XRDResult):
                 range=y_range,
             ),
             template='plotly_white',
+            hovermode='closest',
+            hoverlabel=dict(
+                bgcolor='white',
+            ),
+            dragmode='zoom',
             width=600,
             height=600,
+        )
+        fig_2theta_omega.update_traces(
+            hovertemplate=(
+                '<i>Intensity</i>: %{z:.2f}<br>'
+                '2<i>θ</i>: %{y}°<br>'
+                '<i>ω</i>: %{x}°'
+            )
+        )
+        plot_json = fig_2theta_omega.to_plotly_json()
+        plot_json['config'] = dict(
+            scrollZoom=False,
         )
         plots.append(
             PlotlyFigure(
                 label='RSM 2θ-ω',
                 index=1,
-                figure=fig_2theta_omega.to_plotly_json(),
+                figure=plot_json,
             ),
         )
 
@@ -661,14 +716,30 @@ class XRDResultRSM(XRDResult):
                     range=y_range,
                 ),
                 template='plotly_white',
+                hovermode='closest',
+                hoverlabel=dict(
+                    bgcolor='white',
+                ),
+                dragmode='zoom',
                 width=600,
                 height=600,
+            )
+            fig_q_vector.update_traces(
+                hovertemplate=(
+                    '<i>Intensity</i>: %{z:.2f}<br>'
+                    '<i>q</i><sub>&#x22A5;</sub>: %{y}Å<sup>-1</sup><br>'
+                    '<i>q</i><sub>&#x2016;</sub>: %{x}Å<sup>-1</sup>'
+                    )
+                )
+            plot_json = fig_q_vector.to_plotly_json()
+            plot_json['config'] = dict(
+                scrollZoom=False,
             )
             plots.append(
                 PlotlyFigure(
                     label='RSM Q-vectors',
                     index=0,
-                    figure=fig_q_vector.to_plotly_json(),
+                    figure=plot_json,
                 ),
             )
 


### PR DESCRIPTION
- [x] Zoom along both axes of XRD line plots. 
- [x] Center the title for the plots
- [x] Use 'plotly_white' theme for a white background in plots
- [x] RSM
  - [x] format the axis label
  - [x] format colorbar ticks and title
- [x] Add default name of the `result` section
- [x] If sample_id is not found in raw file, do not initiate a sample. Pass an empty list to `samples` instead.
- [x] Add `intensity` vs `q_norm` plot in XRD 1D results
- [x] Add plot annotations to XRD 1D results for the following quantities: `intensity`, `two_theta`, `q_norm`