### PR TITLE
Add RSM to `results.XRDMethod`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = [
-    "nomad-lab>=1.2.2.dev399",
+    "nomad-lab>=1.3.3.dev86",
     "xmltodict==0.13.0",
 ]
 [project.optional-dependencies]

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -619,7 +619,7 @@ class XRayDiffraction(Measurement):
         | **Small-Angle X-ray Scattering (SAXS)**                    | Used for studying nanostructures in the size range of 1-100 nm. Provides information on particle size, shape, and distribution.                                                                             |
         | **X-ray Reflectivity (XRR)**                               | Used to study thin film layers, interfaces, and multilayers. Provides info on film thickness, density, and roughness.                                                                                       |
         | **Grazing Incidence X-ray Diffraction (GIXRD)**            | Primarily used for the analysis of thin films with the incident beam at a fixed shallow angle.                                                                                                              |
-        | **Reciprocal Space Mapping (RSM)**                         | High-resolution XRD method to measure a reciprocal space map. Provides additional information used to aid the interpretation of peak displacement, peak broadening or peak overlap.                                                                                                                                                             |
+        | **Reciprocal Space Mapping (RSM)**                         | High-resolution XRD method to measure diffracted intensity in a 2-dimensional region of reciprocal space. Provides information about the real-structure (lattice mismatch, domain structure, stress and defects) in single-crystalline and epitaxial samples.|
         ''',
     )
     results = Measurement.results.m_copy()

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -606,7 +606,7 @@ class XRayDiffraction(Measurement):
                 'Small-Angle X-Ray Scattering (SAXS)',
                 'X-Ray Reflectivity (XRR)',
                 'Grazing Incidence X-Ray Diffraction (GIXRD)',
-                # 'Reciprocal Space Mapping (RSM)',
+                'Reciprocal Space Mapping (RSM)',
             ]
         ),
         description='''
@@ -619,8 +619,8 @@ class XRayDiffraction(Measurement):
         | **Small-Angle X-ray Scattering (SAXS)**                    | Used for studying nanostructures in the size range of 1-100 nm. Provides information on particle size, shape, and distribution.                                                                             |
         | **X-ray Reflectivity (XRR)**                               | Used to study thin film layers, interfaces, and multilayers. Provides info on film thickness, density, and roughness.                                                                                       |
         | **Grazing Incidence X-ray Diffraction (GIXRD)**            | Primarily used for the analysis of thin films with the incident beam at a fixed shallow angle.                                                                                                              |
+        | **Reciprocal Space Mapping (RSM)**                         | High-resolution XRD method to measure a reciprocal space map. Provides additional information used to aid the interpretation of peak displacement, peak broadening or peak overlap.                                                                                                                                                             |
         ''',
-        # | **Reciprocal Space Mapping (RSM)**                         | High-resolution XRD method to measure a reciprocal space map. Provides additional information used to aid the interpretation of peak displacement, peak broadening or peak overlap.                                                                                                                                                             |
     )
     results = Measurement.results.m_copy()
     results.section_def = XRDResult


### PR DESCRIPTION
Reciprocal Space Map (RSM) is now implemented in the `nomad_measurement.xrd` plugin. To add RSM method in the explore filters, RSM should be added as an enum value in the `diffraction_method_name` quantity of `nomad.datamodel.results.XRDMethod`.

Corresponding MR on GitLab: https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/1846