### PR TITLE
Bugfix: shape error in DiffractionPattern for RSM

### DIFF
--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -844,6 +844,15 @@ class XRayDiffraction(Measurement):
                             q_vector=result.q_norm,
                         )
                     )
+                elif len(result.intensity.shape) == 2:
+                    diffraction_patterns.append(
+                        DiffractionPattern(
+                            incident_beam_wavelength=result.source_peak_wavelength,
+                            two_theta_angles=result.two_theta,
+                            intensity=result.intensity[0],
+                            q_vector=result.q_perpendicular[0],
+                        )
+                    )
             archive.results.properties.structural = StructuralProperties(
                 diffraction_pattern=diffraction_patterns
             )

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -844,15 +844,6 @@ class XRayDiffraction(Measurement):
                             q_vector=result.q_norm,
                         )
                     )
-                elif len(result.intensity.shape) == 2:
-                    diffraction_patterns.append(
-                        DiffractionPattern(
-                            incident_beam_wavelength=result.source_peak_wavelength,
-                            two_theta_angles=result.two_theta,
-                            intensity=result.intensity[0],
-                            q_vector=result.q_perpendicular[0],
-                        )
-                    )
             archive.results.properties.structural = StructuralProperties(
                 diffraction_pattern=diffraction_patterns
             )

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -833,13 +833,19 @@ class XRayDiffraction(Measurement):
         if not archive.results.properties:
             archive.results.properties = Properties()
         if not archive.results.properties.structural:
+            diffraction_patterns = []
+            for result in self.results:
+                if len(result.intensity.shape) == 1:
+                    diffraction_patterns.append(
+                        DiffractionPattern(
+                            incident_beam_wavelength=result.source_peak_wavelength,
+                            two_theta_angles=result.two_theta,
+                            intensity=result.intensity,
+                            q_vector=result.q_norm,
+                        )
+                    )
             archive.results.properties.structural = StructuralProperties(
-                diffraction_pattern=[DiffractionPattern(
-                    incident_beam_wavelength=result.source_peak_wavelength,
-                    two_theta_angles=result.two_theta,
-                    intensity=result.intensity,
-                    q_vector=result.q_norm,
-                ) for result in self.results]
+                diffraction_pattern=diffraction_patterns
             )
         if not archive.results.method:
             archive.results.method = Method(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -58,6 +58,7 @@ def test_normalize_all(parsed_archive):
     assert parsed_archive.data.results[
         0
     ].source_peak_wavelength.magnitude == pytest.approx(1.540598, 1e-2)
-    assert parsed_archive.results.properties.structural.diffraction_pattern[
-        0
-    ].incident_beam_wavelength.magnitude * 1e10 == pytest.approx(1.540598, 1e-2)
+    if len(parsed_archive.data.results[0].intensity.shape) == 1:
+        assert parsed_archive.results.properties.structural.diffraction_pattern[
+            0
+        ].incident_beam_wavelength.magnitude * 1e10 == pytest.approx(1.540598, 1e-2)


### PR DESCRIPTION
`nomad.datamodel.results.DiffractionPattern.intensity` quantity requires the shape to be `['*']`. On the other hand, `nomad-measurement.xrd.XRDResultRSM.intensity` has the shape `['*','*']`. 

When adding the diffraction pattern in the structural properties, we populate the prior one with the latter one. This generates an error on the latest nomad dev because of the stricter shape checks. 

Fix this by:

  - [x] Only populate the DiffractionPattern if the intensity is 1D