### PR TITLE
137 merge sections break for non scalar quantities

### DIFF
--- a/src/nomad_measurements/utils.py
+++ b/src/nomad_measurements/utils.py
@@ -93,8 +93,7 @@ def merge_sections(  # noqa: PLR0912
             continue
         if not section.m_is_set(quantity):
             section.m_set(quantity, update.m_get(quantity))
-            continue
-        if _not_equal(section.m_get(quantity), update.m_get(quantity)):
+        elif _not_equal(section.m_get(quantity), update.m_get(quantity)):
             warning = f'Merging sections with different values for quantity "{name}".'
             if logger:
                 logger.warning(warning)

--- a/src/nomad_measurements/utils.py
+++ b/src/nomad_measurements/utils.py
@@ -95,7 +95,7 @@ def merge_sections(  # noqa: PLR0912
             section.m_set(quantity, update.m_get(quantity))
             continue
         if _not_equal(section.m_get(quantity), update.m_get(quantity)):
-            warning = f'Merging different values for "{name}" quantity.'
+            warning = f'Merging sections with different values for quantity "{name}".'
             if logger:
                 logger.warning(warning)
             else:

--- a/src/nomad_measurements/utils.py
+++ b/src/nomad_measurements/utils.py
@@ -67,6 +67,12 @@ def create_archive(
     )
 
 
+def _not_equal(a, b) -> bool:
+    if isinstance(a, np.ndarray):
+        return (a != b).any()
+    return a != b
+
+
 def merge_sections(  # noqa: PLR0912
     section: 'ArchiveSection',
     update: 'ArchiveSection',
@@ -87,13 +93,9 @@ def merge_sections(  # noqa: PLR0912
             continue
         if not section.m_is_set(quantity):
             section.m_set(quantity, update.m_get(quantity))
-        elif (
-            quantity.is_scalar
-            and section.m_get(quantity) != update.m_get(quantity)
-            or not quantity.is_scalar
-            and (section.m_get(quantity) != update.m_get(quantity)).any()
-        ):
-            warning = f'Merging sections with different values for quantity "{name}".'
+            continue
+        if _not_equal(section.m_get(quantity), update.m_get(quantity)):
+            warning = f'Merging different values for "{name}" quantity.'
             if logger:
                 logger.warning(warning)
             else:

--- a/tests/test_first_utils.py
+++ b/tests/test_first_utils.py
@@ -78,9 +78,9 @@ def test_merge_sections(capfd):
     merge_sections(system_1, system_2)
     out, _ = capfd.readouterr()
     assert out == (
-        'Merging different values for "float_array" quantity.\n'
-        'Merging different values for "bool_array" quantity.\n'
-        'Merging different values for "name" quantity.\n'
+        'Merging sections with different values for quantity "float_array".\n'
+        'Merging sections with different values for quantity "bool_array".\n'
+        'Merging sections with different values for quantity "name".\n'
     )
     assert system_1.components[0].mass_fraction == 1
     assert system_1.components[0].name == 'Cu'

--- a/tests/test_first_utils.py
+++ b/tests/test_first_utils.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+import numpy as np
 from nomad.datamodel.metainfo.basesections import (
     Component,
     CompositeSystem,
@@ -30,6 +31,7 @@ from nomad_measurements.utils import (
 
 
 class TestComponent(Component):
+    float_array = Quantity(type=np.float64, shape=["*"])
     bool_array = Quantity(type=bool, shape=["*"])
     enum_value = Quantity(type=MEnum(['A', 'B', 'C']))
 
@@ -37,13 +39,15 @@ class TestComponent(Component):
 def test_merge_sections():
     component_1 = TestComponent(
         mass_fraction=1,
-        bool_value=[True, False],
+        float_array=[1.0, 2.0],
+        bool_array=[True, False],
         enum_value='A',
     )
     component_2 = TestComponent(
         name='Cu',
         mass_fraction=1,
-        bool_value=[True, True],
+        float_array=[1.0, 3.0],
+        bool_array=[True, True],
         enum_value='A',
     )
     substance_1 = PureSubstanceSection(
@@ -74,8 +78,8 @@ def test_merge_sections():
     merge_sections(system_1, system_2)
     assert system_1.components[0].mass_fraction == 1
     assert system_1.components[0].name == 'Cu'
-    assert system_1.components[0].bool_value[0] is True
-    assert system_1.components[0].bool_value[1] is False
+    assert system_1.components[0].bool_array[0] is True
+    assert system_1.components[0].bool_array[1] is False
     assert system_1.components[0].enum_value == 'A'
     assert system_1.components[1].name == 'Cu'
     assert system_1.components[1].pure_substance.name == 'Cu'

--- a/tests/test_first_utils.py
+++ b/tests/test_first_utils.py
@@ -22,19 +22,29 @@ from nomad.datamodel.metainfo.basesections import (
     PureSubstanceComponent,
     PureSubstanceSection,
 )
+from nomad.metainfo import MEnum, Quantity
 
 from nomad_measurements.utils import (
     merge_sections,
 )
 
 
+class TestComponent(Component):
+    bool_array = Quantity(type=bool, shape=["*"])
+    enum_value = Quantity(type=MEnum(['A', 'B', 'C']))
+
+
 def test_merge_sections():
-    component_1 = Component(
+    component_1 = TestComponent(
         mass_fraction=1,
+        bool_value=[True, False],
+        enum_value='A',
     )
-    component_2 = Component(
+    component_2 = TestComponent(
         name='Cu',
         mass_fraction=1,
+        bool_value=[True, True],
+        enum_value='A',
     )
     substance_1 = PureSubstanceSection(
         name='Cu',
@@ -64,6 +74,9 @@ def test_merge_sections():
     merge_sections(system_1, system_2)
     assert system_1.components[0].mass_fraction == 1
     assert system_1.components[0].name == 'Cu'
+    assert system_1.components[0].bool_value[0] is True
+    assert system_1.components[0].bool_value[1] is False
+    assert system_1.components[0].enum_value == 'A'
     assert system_1.components[1].name == 'Cu'
     assert system_1.components[1].pure_substance.name == 'Cu'
     assert system_1.components[1].pure_substance.iupac_name == 'Copper'

--- a/tests/test_first_utils.py
+++ b/tests/test_first_utils.py
@@ -36,10 +36,10 @@ class TestComponent(Component):
     enum_value = Quantity(type=MEnum(['A', 'B', 'C']))
 
 
-def test_merge_sections():
+def test_merge_sections(capfd):
     component_1 = TestComponent(
         mass_fraction=1,
-        float_array=[1.0, 2.0],
+        float_array=[1.0, 1.0],
         bool_array=[True, False],
         enum_value='A',
     )
@@ -76,10 +76,18 @@ def test_merge_sections():
     )
     system_3 = CompositeSystem()
     merge_sections(system_1, system_2)
+    out, _ = capfd.readouterr()
+    assert out == (
+        'Merging different values for "float_array" quantity.\n'
+        'Merging different values for "bool_array" quantity.\n'
+        'Merging different values for "name" quantity.\n'
+    )
     assert system_1.components[0].mass_fraction == 1
     assert system_1.components[0].name == 'Cu'
     assert system_1.components[0].bool_array[0] is True
     assert system_1.components[0].bool_array[1] is False
+    assert system_1.components[0].float_array[0] == 1.0
+    assert system_1.components[0].float_array[1] == 1.0
     assert system_1.components[0].enum_value == 'A'
     assert system_1.components[1].name == 'Cu'
     assert system_1.components[1].pure_substance.name == 'Cu'

--- a/tests/test_first_utils.py
+++ b/tests/test_first_utils.py
@@ -31,8 +31,8 @@ from nomad_measurements.utils import (
 
 
 class TestComponent(Component):
-    float_array = Quantity(type=np.float64, shape=["*"])
-    bool_array = Quantity(type=bool, shape=["*"])
+    float_array = Quantity(type=np.float64, shape=['*'])
+    bool_array = Quantity(type=bool, shape=['*'])
     enum_value = Quantity(type=MEnum(['A', 'B', 'C']))
 
 


### PR DESCRIPTION
Added a fix for where array quantities of non numpy type would cause `nomad_measurements.utils.merge_sections` to fail.