### PR TITLE
Fix data file path in parsers

### DIFF
--- a/src/nomad_measurements/transmission/parser.py
+++ b/src/nomad_measurements/transmission/parser.py
@@ -40,7 +40,7 @@ class TransmissionParser(MatchingParser):
     def parse(
         self, mainfile: str, archive: 'EntryArchive', logger=None, child_archives=None
     ) -> None:
-        data_file = mainfile.split('/')[-1]
+        data_file = mainfile.split('/raw/', 1)[1]
         entry = ELNUVVisNirTransmission.m_from_dict(
             ELNUVVisNirTransmission.m_def.a_template
         )

--- a/src/nomad_measurements/xrd/parser.py
+++ b/src/nomad_measurements/xrd/parser.py
@@ -39,7 +39,7 @@ class XRDParser(MatchingParser):
     def parse(
         self, mainfile: str, archive: 'EntryArchive', logger=None, child_archives=None
     ) -> None:
-        data_file = mainfile.split('/')[-1]
+        data_file = mainfile.split('/raw/', 1)[1]
         entry = ELNXRayDiffraction.m_from_dict(ELNXRayDiffraction.m_def.a_template)
         entry.data_file = data_file
         file_name = f'{"".join(data_file.split(".")[:-1])}.archive.json'


### PR DESCRIPTION
Currently, when a raw data file is dropped in the upload, the parser picks its file name (not the file path) and sets it as the `data_file` path in the ELN. This makes a hidden assumption that the file is always present in the top-most folder, like `<upload_path>/raw/<data_file>`. 

However, this breaks when a zip file containing raw file(s) is dropped. NOMAD unzips the file in a sub-folder structure, like `<upload_path>/raw/sub-folder-path/<data_file>`. The parser picks the file name and sets the `data_file` path as `<upload_path>/raw/<data_file>`, not taking into account the sub-folder structure.

When ELN tries to open the data file, it runs into an error as the file is not found at the given path.

The solution here solves this.