### PR TITLE
Remove support for py39

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.9", "3.10", "3.11"]
+        python_version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{matrix.python_version}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -20,7 +19,7 @@ name = "nomad-measurements"
 dynamic = ["version"]
 description = "A plugin for NOMAD containing base sections for measurements."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Andrea Albino" },
     { name = "Sebastian Brückner" },
@@ -35,7 +34,7 @@ maintainers = [
 ]
 license = { file = "LICENSE" }
 dependencies = [
-    "nomad-lab>=1.3.6", 
+    "nomad-lab>=1.3.14",
     "xmltodict==0.13.0",
     "fairmat-readers-xrd>=0.0.3",
     "nomad-material-processing",

--- a/src/nomad_measurements/transmission/schema.py
+++ b/src/nomad_measurements/transmission/schema.py
@@ -30,11 +30,10 @@ If you want a corresponding ELN schema, create a new class with the signature:
 For example, ELNUVVisNirTransmission(UVVisNirTransmission, PlotSection, EntryData).
 """
 
+from collections.abc import Callable
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
-    Union,
 )
 
 import numpy as np
@@ -1077,7 +1076,7 @@ class ELNUVVisNirTransmission(UVVisNirTransmission, PlotSection, EntryData):
 
     def get_instrument_reference(
         self, data_dict: dict[str, Any], archive: 'EntryArchive', logger: 'BoundLogger'
-    ) -> Union[InstrumentReference, None]:
+    ) -> InstrumentReference | None:
         """
         Method for getting the instrument reference.
         Looks for an existing instrument with the given serial number.

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -15,10 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from collections.abc import Callable
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
 )
 
 import numpy as np


### PR DESCRIPTION
- [x] Remove support for py39
- [x] Upgrade nomad to `1.3.14`

## Summary by Sourcery

Remove support for Python 3.9 and upgrade the nomad-lab dependency to version 1.3.14.

Build:
- Update the supported Python versions to 3.10, 3.11, and 3.12.
- Update the nomad-lab dependency to version 1.3.14.