### PR TITLE
Read hdf5 dataset via api

### DIFF
--- a/src/nomad_measurements/utils.py
+++ b/src/nomad_measurements/utils.py
@@ -27,6 +27,9 @@ from typing import (
 import h5py
 import numpy as np
 import pint
+import requests
+from nomad.client import Auth
+from nomad.config import config
 from nomad.datamodel.context import ClientContext
 from nomad.datamodel.hdf5 import HDF5Reference
 from nomad.units import ureg
@@ -629,3 +632,75 @@ def resolve_path(section: 'ArchiveSection', path: str, logger: 'BoundLogger' = N
         return None
 
     return attr
+
+
+def read_hdf5_dataset(
+    file_path: str, dataset_path: str, archive: 'ArchiveSection' = None
+) -> np.ndarray | pint.Quantity:
+    """
+    Read the dataset from the HDF5 file. If the HDF5 file is not available locally, the
+    function tries to download the file from the NOMAD server using the
+    context of the provided archive.
+
+    Args:
+        file_path (str): The path of the HDF5 file.
+        dataset_path (str): The dataset path in the HDF5 file.
+        archive (ArchiveSection): The NOMAD archive.
+        TODO test if this works for EntryArchive or only EntryData
+
+    Returns:
+        np.ndarray | pint.Quantity: The dataset or None if not found.
+    """
+    if not os.path.exists(file_path):
+        if not archive:
+            raise ValueError(
+                'A NOMAD Archive is required to locate the file on NOMAD server.'
+            )
+        get_raw_file(
+            file_path,
+            archive.m_context.upload_id,
+            archive.m_context.installation_url,
+        )
+    value = None
+    with h5py.File(file_path, 'r') as h5:
+        if dataset_path in h5:
+            value = h5[dataset_path][...]
+            try:
+                units = h5[dataset_path].attrs['units']
+                value *= ureg(units)
+            except KeyError:
+                pass
+    return value
+
+
+def get_raw_file(
+    path: str,
+    upload_id: str,
+    base_url: str,
+    user: str = config.client.user,
+    password: str = config.client.password,
+):
+    """
+    Downloads the raw file from the NOMAD server using the API endpoint
+    `/uploads/{upload_id}/raw/{path}`.
+
+    Attributes:
+        path (str): The path of the raw file to be downloaded.
+        upload_id (str): The upload ID of the raw file.
+        base_url (str): The base URL of the NOMAD server.
+        user (str): The username for authentication.
+        password (str): The password for authentication.
+    """
+    headers = {**Auth(user=user, password=password).headers()}
+
+    if path is None:
+        path = ''
+    endpoint = f'{base_url}/uploads/{upload_id}/raw/{path}'
+
+    response = requests.get(endpoint, headers=headers, timeout=120)
+
+    response.raise_for_status()
+
+    with open(path, 'wb') as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)


### PR DESCRIPTION
`HDF5Reference` quantities were introduced recently in the XRD results sections, where the data is stored in HDF5 files or NeXus files and only a reference to the data is stored in the entry. However, when downloading the entry over the API using `ArchiveQuery`, the user only gets the reference paths for these quantities. There's a need for a util function resolves these reference paths on the client side.

- [x] Adds a util function to resolve the `HDF5Reference` quantities.

## Summary by Sourcery

Add utility functions to resolve and download HDF5 references from NOMAD server

New Features:
- Implement a function to resolve HDF5 references by downloading files from NOMAD server if not available locally

Enhancements:
- Create a robust method to validate and parse HDF5 references
- Add support for handling units when reading HDF5 datasets