### PR TITLE
Trigger HDF5 section with a switch

### DIFF
--- a/src/nomad_measurements/utils.py
+++ b/src/nomad_measurements/utils.py
@@ -55,10 +55,6 @@ if TYPE_CHECKING:
     )
 
 
-class NXFileGenerationError(Exception):
-    pass
-
-
 def get_reference(upload_id: str, entry_id: str) -> str:
     return f'../uploads/{upload_id}/archive/{entry_id}#data'
 

--- a/src/nomad_measurements/xrd/__init__.py
+++ b/src/nomad_measurements/xrd/__init__.py
@@ -1,7 +1,13 @@
 from nomad.config.models.plugins import ParserEntryPoint, SchemaPackageEntryPoint
+from pydantic import Field
 
 
 class XRDSchemaPackageEntryPoint(SchemaPackageEntryPoint):
+    use_hdf5_results: bool = Field(
+        default=False,
+        description='Whether to use HDF5 results sections by default.',
+    )
+
     def load(self):
         from nomad_measurements.xrd.schema import m_package
 

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -1840,11 +1840,11 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
         if isinstance(self.results[0], XRDResult1D):
             self.results = [XRDResult1DHDF5()]
             self.figures = []
-            self.update_nexus_file = True
+            self.trigger_update_nexus_file = True
         elif isinstance(self.results[0], XRDResultRSM):
             self.results = [XRDResultRSMHDF5()]
             self.figures = []
-            self.update_nexus_file = True
+            self.trigger_update_nexus_file = True
         elif isinstance(self.results[0], XRDResult1DHDF5):
             self.results = [XRDResult1D()]
             self.auxiliary_file = None
@@ -1893,7 +1893,7 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
             self.figures = self.results[0].generate_plots()
         elif (
             isinstance(self.results[0], XRDResult1DHDF5 | XRDResultRSMHDF5)
-            and self.update_nexus_file
+            and self.trigger_update_nexus_file
         ):
             filename = self.data_file.rsplit('.', 1)[0]
             self.auxiliary_file = (
@@ -1970,7 +1970,7 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
                 )
                 self.nexus_view = get_reference(archive.metadata.upload_id, nx_entry_id)
 
-            self.update_nexus_file = False
+            self.trigger_update_nexus_file = False
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
         """

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -1763,7 +1763,7 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
         """,
         a_eln=dict(component='ActionEditQuantity', label='Switch Results Section'),
     )
-    update_nexus_file = Quantity(
+    trigger_update_nexus_file = Quantity(
         type=bool,
         description="""
         Updates the nexus file with the current ELN state, if the results section uses
@@ -1994,7 +1994,7 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
             xrd_dict = read_function(file.name, logger)
         write_function(xrd_dict, archive, logger)
 
-        # setup results section
+        # set up results section
         if not self.results:
             scan_type = xrd_dict.get('metadata', {}).get('scan_type')
             if scan_type not in ['line', 'rsm']:

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -49,7 +49,7 @@ from nomad.datamodel.metainfo.basesections import (
     MeasurementResult,
     ReadableIdentifiers,
 )
-from nomad.datamodel.metainfo.plot import PlotlyFigure
+from nomad.datamodel.metainfo.plot import PlotlyFigure, PlotSection
 from nomad.datamodel.results import (
     DiffractionPattern,
     MeasurementMethod,
@@ -1708,7 +1708,7 @@ class XRayDiffraction(Measurement):
             )
 
 
-class ELNXRayDiffraction(XRayDiffraction, EntryData):
+class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
     """
     Example section for how XRayDiffraction can be implemented with a general reader for
     common XRD file types.
@@ -1761,9 +1761,6 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData):
     auxiliary_file = Quantity(
         type=str,
         description='Auxiliary file (like .h5 or .nxs) containing the entry data.',
-        a_eln=ELNAnnotation(
-            component=ELNComponentEnum.FileEditQuantity,
-        ),
         a_browser=BrowserAnnotation(adaptor='RawFileAdaptor'),
     )
     nexus_view = Quantity(
@@ -1771,12 +1768,23 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData):
         description='Reference to the NeXus entry.',
         a_eln=ELNAnnotation(component=ELNComponentEnum.ReferenceEditQuantity),
     )
-    overwrite_auxiliary_file = Quantity(
+    trigger_switch_results_section = Quantity(
         type=bool,
-        description='Overwrite the auxiliary file with the current data.',
-        a_eln=ELNAnnotation(
-            component=ELNComponentEnum.BoolEditQuantity,
-        ),
+        description="""
+        Switches the results section. If it is a non-HDF5 section, it will be converted
+        to HDF5 section (using NeXus file in the backend) and vice versa.
+        If the results contains large datasets and the entry takes longer to process,
+        it is recommended to use the HDF5 section.
+        """,
+        a_eln=dict(component='ActionEditQuantity', label='Switch Results Section'),
+    )
+    update_nexus_file = Quantity(
+        type=bool,
+        description="""
+        Updates the nexus file with the current ELN state, if the results section uses
+        HDF5 references along with a NeXus file.
+        """,
+        a_eln=dict(component='ActionEditQuantity', label='Update NeXus File'),
     )
 
     def get_read_write_functions(self) -> tuple[Callable, Callable]:

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -1840,9 +1840,11 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
         if isinstance(self.results[0], XRDResult1D):
             self.results = [XRDResult1DHDF5()]
             self.figures = []
+            self.update_nexus_file = True
         elif isinstance(self.results[0], XRDResultRSM):
             self.results = [XRDResultRSMHDF5()]
             self.figures = []
+            self.update_nexus_file = True
         elif isinstance(self.results[0], XRDResult1DHDF5):
             self.results = [XRDResult1D()]
             self.auxiliary_file = None
@@ -1889,7 +1891,10 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
                     setattr(self.results[0], k, v)
             self.results[0].normalize(archive, logger)
             self.figures = self.results[0].generate_plots()
-        elif isinstance(self.results[0], XRDResult1DHDF5 | XRDResultRSMHDF5):
+        elif (
+            isinstance(self.results[0], XRDResult1DHDF5 | XRDResultRSMHDF5)
+            and self.update_nexus_file
+        ):
             filename = self.data_file.rsplit('.', 1)[0]
             self.auxiliary_file = (
                 f'{filename}.h5'
@@ -1964,6 +1969,8 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
                     archive=archive, file_name=self.auxiliary_file
                 )
                 self.nexus_view = get_reference(archive.metadata.upload_id, nx_entry_id)
+
+            self.update_nexus_file = False
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
         """

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -1856,7 +1856,7 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
             self.auxiliary_file = None
             self.nexus_view = None
 
-    def populate_results_section(
+    def populate_measurement_results(
         self, xrd_dict: dict, archive: 'EntryArchive', logger: 'BoundLogger'
     ):
         """
@@ -2015,8 +2015,8 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
             self.switch_results_section()
             self.trigger_switch_results_section = False
 
-        # populate the results section
-        self.populate_results_section(xrd_dict, archive, logger)
+        # populate the measurement results section
+        self.populate_measurement_results(xrd_dict, archive, logger)
 
         super().normalize(archive, logger)
 

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -1646,6 +1646,15 @@ class XRayDiffraction(Measurement):
             logger (BoundLogger): A structlog logger.
         """
         super().normalize(archive, logger)
+        if (
+            self.xrd_settings is not None
+            and self.xrd_settings.source is not None
+            and self.xrd_settings.source.kalpha_one is not None
+        ):
+            for result in self.results:
+                if result.source_peak_wavelength is None:
+                    result.source_peak_wavelength = self.xrd_settings.source.kalpha_one
+                    result.normalize(archive, logger)
 
         if not archive.results:
             archive.results = Results()


### PR DESCRIPTION
- [x] Setup parallel normalizing chain for HDF5 and non-HDF5 sections
- [x] Expose a config to use HDF5 results by default
- [x] Implement switch 'Switch To/From HDF5 Results'
- [x] Implement switch 'Update Nexus File'
- [x] ELNXRayDiffraction will be a PlotSection: whether it is with or without figures depends on the results section used.
- [x] Remove the back_compatibility method as it is not required

## Summary by Sourcery

Chores:
- Remove unused NXFileGenerationError exception from utils module