### PR TITLE
Fixed `merge_sections()` utility function for different array lengths

### DIFF
--- a/src/nomad_measurements/utils.py
+++ b/src/nomad_measurements/utils.py
@@ -93,7 +93,11 @@ def create_archive(
 
 
 def _not_equal(a, b) -> bool:
-    comparison = a != b
+    try:
+        comparison = a != b
+    except ValueError:
+        # If the comparison fails, we assume they are not equal
+        return True
     if isinstance(comparison, np.ndarray):
         return comparison.any()
     return comparison

--- a/tests/test_first_utils.py
+++ b/tests/test_first_utils.py
@@ -34,6 +34,7 @@ from nomad_measurements.utils import (
 class TestComponent(Component):
     float_array = Quantity(type=np.float64, shape=[2, '*'])
     float_array_w_units = Quantity(type=np.float64, shape=['*'], unit='eV')
+    float_array_w_diff_length = Quantity(type=np.float64, shape=['*'])
     bool_array = Quantity(type=bool, shape=['*'])
     enum_value = Quantity(type=MEnum(['A', 'B', 'C']))
 
@@ -43,6 +44,7 @@ def test_merge_sections(capfd):
         mass_fraction=1,
         float_array=[[1.0, 1.0], [1.0, 3.0]],
         float_array_w_units=[1.0, 1.0],
+        float_array_w_diff_length=[1.0, 3.0],
         bool_array=[True, False],
         enum_value='A',
     )
@@ -51,6 +53,7 @@ def test_merge_sections(capfd):
         mass_fraction=1,
         float_array=[[1.0, 3.0], [1.0, 3.0]],
         float_array_w_units=[1.0, 1.0],
+        float_array_w_diff_length=[1.0, 3.0, 4.0],
         bool_array=[True, True],
         enum_value='A',
     )

--- a/tests/test_first_utils.py
+++ b/tests/test_first_utils.py
@@ -86,6 +86,8 @@ def test_merge_sections(capfd):
     out, _ = capfd.readouterr()
     assert out == (
         'Merging sections with different values for quantity "float_array".\n'
+        'Merging sections with different values for quantity '
+        '"float_array_w_diff_length".\n'
         'Merging sections with different values for quantity "bool_array".\n'
         'Merging sections with different values for quantity "name".\n'
     )


### PR DESCRIPTION
This pull request includes changes to the `src/nomad_measurements/utils.py` and `tests/test_first_utils.py` files. The changes primarily focus on improving the handling of comparisons and enhancing test coverage.

Improvements to comparison handling:

* [`src/nomad_measurements/utils.py`](diffhunk://#diff-89fc41b64fc96cc8c9d4e9639de86b11f0f412d4c3da0673840029599fc76838R96-R100): Modified the `_not_equal` function to handle `ValueError` exceptions, ensuring that failed comparisons are treated as not equal.

Enhancements to test coverage:

* [`tests/test_first_utils.py`](diffhunk://#diff-a8665f2efdc62b78d417959f2f47a37b186437cc8f87db3c335faefe6d8ad018R37): Added a new quantity `float_array_w_diff_length` to the `TestComponent` class to test arrays with different lengths.
* [`tests/test_first_utils.py`](diffhunk://#diff-a8665f2efdc62b78d417959f2f47a37b186437cc8f87db3c335faefe6d8ad018R47): Updated the `test_merge_sections` function to include cases for `float_array_w_diff_length`, ensuring that the merging of sections with different array lengths is tested. [[1]](diffhunk://#diff-a8665f2efdc62b78d417959f2f47a37b186437cc8f87db3c335faefe6d8ad018R47) [[2]](diffhunk://#diff-a8665f2efdc62b78d417959f2f47a37b186437cc8f87db3c335faefe6d8ad018R56) [[3]](diffhunk://#diff-a8665f2efdc62b78d417959f2f47a37b186437cc8f87db3c335faefe6d8ad018R89-R90)

## Summary by Sourcery

Improve error handling and test coverage for section merging utility function

Bug Fixes:
- Enhanced error handling in comparison function to gracefully handle `ValueError` exceptions during array comparisons

Enhancements:
- Modified comparison logic to handle edge cases in array comparisons
- Improved error resilience in utility function

Tests:
- Added test cases for arrays with different lengths to improve test coverage of the `merge_sections()` utility function
- Extended test scenarios to validate merging behavior with arrays of varying lengths