### PR TITLE
Changed `utils.create_archive` to use `update_entry`

### DIFF
--- a/src/nomad_measurements/utils.py
+++ b/src/nomad_measurements/utils.py
@@ -69,20 +69,15 @@ def create_archive(
     entity: 'ArchiveSection',
     archive: 'EntryArchive',
     file_name: str,
+    overwrite: bool=False,
 ) -> str:
-    import json
-
-    from nomad.datamodel.context import ClientContext
-
-    entity_entry = entity.m_to_dict(with_root_def=True)
-    if isinstance(archive.m_context, ClientContext):
-        with open(file_name, 'w') as outfile:
-            json.dump({'data': entity_entry}, outfile, indent=4)
-        return os.path.abspath(file_name)
-    if not archive.m_context.raw_path_exists(file_name):
-        with archive.m_context.raw_file(file_name, 'w') as outfile:
-            json.dump({'data': entity_entry}, outfile)
-        archive.m_context.process_updated_raw_file(file_name)
+    if overwrite or not archive.m_context.raw_path_exists(file_name):
+        with archive.m_context.update_entry(
+            file_name,
+            write=True,
+            process=True
+        ) as entry:
+            entry['data'] = entity.m_to_dict(with_root_def=True)
     return get_reference(
         archive.metadata.upload_id, get_entry_id_from_file_name(file_name, archive)
     )

--- a/src/nomad_measurements/utils.py
+++ b/src/nomad_measurements/utils.py
@@ -69,13 +69,11 @@ def create_archive(
     entity: 'ArchiveSection',
     archive: 'EntryArchive',
     file_name: str,
-    overwrite: bool=False,
+    overwrite: bool = False,
 ) -> str:
     if overwrite or not archive.m_context.raw_path_exists(file_name):
         with archive.m_context.update_entry(
-            file_name,
-            write=True,
-            process=True
+            file_name, write=True, process=True
         ) as entry:
             entry['data'] = entity.m_to_dict(with_root_def=True)
     return get_reference(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ import os
 import pytest
 import structlog
 from nomad.client import parse
+from nomad.utils import hash as m_hash
 from nomad.utils import structlogging
 from structlog.testing import LogCapture
 
@@ -86,8 +87,10 @@ def fixture_parsed_measurement_archive(request):
     rel_measurement_archive_path = os.path.join(
         rel_file_path.rsplit('.', 1)[0] + '.archive.json'
     )
-    assert file_archive.data.measurement.m_proxy_value == os.path.abspath(
-        rel_measurement_archive_path
+    upload_id = None
+    assert file_archive.data.measurement.m_proxy_value == (
+        f'../uploads/{upload_id}/archive/'
+        f'{m_hash(upload_id, os.path.basename(rel_measurement_archive_path))}#data'
     )
 
     yield parse(rel_measurement_archive_path)[0]


### PR DESCRIPTION
## Summary by Sourcery

Refactor create_archive to use the update_entry API for writing and introduce an overwrite option

Enhancements:
- Add overwrite parameter to create_archive to allow force-updating existing entries
- Replace manual json dumping and file context handling with archive.m_context.update_entry for streamlined entry updates