### PR TITLE
Relax mime type to be generic octet-stream

### DIFF
--- a/src/nomad_measurements/xrd/__init__.py
+++ b/src/nomad_measurements/xrd/__init__.py
@@ -31,5 +31,5 @@ parser_entry_point = XRDParserEntryPoint(
     name='XRD Parser',
     description='Parser for several kinds of raw files from XRD measurements.',
     mainfile_name_re=r'^.*\.xrdml$|^.*\.rasx$|^.*\.brml$',
-    mainfile_mime_re='text/.*|application/zip',
+    mainfile_mime_re='text/.*|application/zip|application/octet-stream',
 )


### PR DESCRIPTION
For some reason, the mime type of `brml` and `rasx` raw files is predicted to be generic `application/octet-stream` rather than `application/zip` by `magic.from_buffer(buffer, mime=True)`. We use this function in `nomad` for matching parser.

```py
import magic

file_path = 'tests/data/xrd/23-012-AG_2thomegascan_long.brml'
with open(file_path, 'rb') as f:
    buffer = f.read(12000)

magic.from_buffer(buffer, mime=True)  # gives 'application/octet-stream'
magic.from_file(file_path, mime=True)  # gives 'application/zip'
```

This PR adds another expected mime for the XRD parser to be `application/octet-stream` to allow file matching.