### PR TITLE
Fix the order of warnings raised in the `merge_section` test

### DIFF
--- a/tests/test_first_utils.py
+++ b/tests/test_first_utils.py
@@ -32,10 +32,10 @@ from nomad_measurements.utils import (
 
 
 class TestComponent(Component):
+    bool_array = Quantity(type=bool, shape=['*'])
     float_array = Quantity(type=np.float64, shape=[2, '*'])
     float_array_w_units = Quantity(type=np.float64, shape=['*'], unit='eV')
     float_array_w_diff_length = Quantity(type=np.float64, shape=['*'])
-    bool_array = Quantity(type=bool, shape=['*'])
     enum_value = Quantity(type=MEnum(['A', 'B', 'C']))
 
 


### PR DESCRIPTION
With the changes made [here](https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/commit/7aaefcc59b8c6d5a06cee7bad2d3bca08c7ccaf1#7bf2dd65bf75c8da49010bf8c55e52c3346c5a33_1009_1041), the attributes of MSection `__dict__` are accessed after sorting. Meaning that when `merge_section` util goes over the quantities for comparison, it does so in alphabetical order.

For the test data, the warning for "bool_array" quantity will appear first in the list of warnings.

## Summary by Sourcery

Tests:
- Reorder expected warning messages in test_merge_sections so that the warning for "bool_array" appears first