### PR TITLE
Migrate to basesection V2

### DIFF
--- a/src/nomad_measurements/general.py
+++ b/src/nomad_measurements/general.py
@@ -24,7 +24,7 @@ from nomad.datamodel.metainfo.annotations import (
     ELNAnnotation,
     ELNComponentEnum,
 )
-from nomad.datamodel.metainfo.basesections import (
+from nomad.datamodel.metainfo.basesections.v2 import (
     Activity,
     Measurement,
     Process,

--- a/src/nomad_measurements/quantumdesign/parser.py
+++ b/src/nomad_measurements/quantumdesign/parser.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     )
 
 from nomad.datamodel import EntryArchive
-from nomad.datamodel.metainfo.basesections import (
+from nomad.datamodel.metainfo.basesections.v2 import (
     BaseSection,
 )
 

--- a/src/nomad_measurements/quantumdesign/qddatastruct.py
+++ b/src/nomad_measurements/quantumdesign/qddatastruct.py
@@ -24,9 +24,9 @@ from nomad.datamodel.data import (
 from nomad.datamodel.metainfo.annotations import (
     ELNAnnotation,
 )
-from nomad.datamodel.metainfo.basesections import (
-    CompositeSystemReference,
+from nomad.datamodel.metainfo.basesections.v2 import (
     MeasurementResult,
+    SystemReference,
 )
 from nomad.metainfo import (
     MEnum,
@@ -48,7 +48,7 @@ class QDSample(ArchiveSection):
         type=str, description='Cross section through which the current flows'
     )
     sample = SubSection(
-        section_def=CompositeSystemReference,
+        section_def=SystemReference,
         description='Reference to the sample measured',
     )
 

--- a/src/nomad_measurements/quantumdesign/qdsteps.py
+++ b/src/nomad_measurements/quantumdesign/qdsteps.py
@@ -21,7 +21,7 @@
 from nomad.datamodel.metainfo.annotations import (
     ELNAnnotation,
 )
-from nomad.datamodel.metainfo.basesections import ActivityStep
+from nomad.datamodel.metainfo.basesections.v2 import ActivityStep
 from nomad.metainfo import (
     MEnum,
     Quantity,

--- a/src/nomad_measurements/quantumdesign/schema.py
+++ b/src/nomad_measurements/quantumdesign/schema.py
@@ -30,7 +30,7 @@ from nomad.datamodel.metainfo.annotations import (
     ELNAnnotation,
     SectionProperties,
 )
-from nomad.datamodel.metainfo.basesections import Measurement
+from nomad.datamodel.metainfo.basesections.v2 import Measurement
 from nomad.datamodel.metainfo.plot import PlotlyFigure, PlotSection
 from nomad.metainfo import (
     Quantity,

--- a/src/nomad_measurements/transmission/schema.py
+++ b/src/nomad_measurements/transmission/schema.py
@@ -50,15 +50,15 @@ from nomad.datamodel.metainfo.annotations import (
     Filter,
     SectionProperties,
 )
-from nomad.datamodel.metainfo.basesections import (
-    CompositeSystem,
-    CompositeSystemReference,
+from nomad.datamodel.metainfo.basesections.v2 import (
     Entity,
     Instrument,
     InstrumentReference,
     Measurement,
     MeasurementResult,
     ReadableIdentifiers,
+    System,
+    SystemReference,
 )
 from nomad.datamodel.metainfo.plot import (
     PlotlyFigure,
@@ -326,7 +326,7 @@ class PerkinElmersLambdaSpectrophotometer(Spectrophotometer):
         super().normalize(archive, logger)
 
 
-class TransmissionSampleReference(CompositeSystemReference):
+class TransmissionSampleReference(SystemReference):
     """
     Reference to the sample used in the transmission measurement. Additionally,
     it contains specific sample properties important for transmission measurements.
@@ -345,7 +345,7 @@ class TransmissionSampleReference(CompositeSystemReference):
         )
     )
     reference = Quantity(
-        type=CompositeSystem,
+        type=System,
         description="""
         A reference to the sample used.
         """,

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -44,11 +44,11 @@ from nomad.datamodel.metainfo.annotations import (
     H5WebAnnotation,
     SectionProperties,
 )
-from nomad.datamodel.metainfo.basesections import (
-    CompositeSystemReference,
+from nomad.datamodel.metainfo.basesections.v2 import (
     Measurement,
     MeasurementResult,
     ReadableIdentifiers,
+    SystemReference,
 )
 from nomad.datamodel.metainfo.plot import PlotlyFigure, PlotSection
 from nomad.datamodel.results import (
@@ -1832,7 +1832,7 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
 
         samples = []
         if metadata_dict.get('sample_id') is not None:
-            sample = CompositeSystemReference(
+            sample = SystemReference(
                 lab_id=metadata_dict['sample_id'],
             )
             sample.normalize(archive, logger)


### PR DESCRIPTION
- [x] Use imports from v2 basesections
- [x] Use System and SystemReferences


Note: Changing the definition of references from `CompositeSystem` to `System` will require that all `CompositeSystem` entries are migrated to `System`.