### PR TITLE
Make pynxtools optional

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -33,10 +33,10 @@ jobs:
         curl -LsSf https://astral.sh/uv/install.sh | sh
     - name: Install dependencies
       run: |
-        uv pip install -e '.[dev, nexus]'
+        uv sync --all-extras
     - name: Test with pytest
       run: |
-        pytest
+        uv run pytest
 
   ruff-linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -33,7 +33,7 @@ jobs:
         curl -LsSf https://astral.sh/uv/install.sh | sh
     - name: Install dependencies
       run: |
-        uv pip install -e '.[dev]'
+        uv pip install -e '.[dev, nexus]'
     - name: Test with pytest
       run: |
         pytest

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install nomad-measurements --index-url https://gitlab.mpcdf.mpg.de/api/v4/pr
 ### Setting up your OASIS
 Read the [NOMAD oasis documentation](https://nomad-lab.eu/prod/v1/docs/howto/oasis/configure.html#plugins) for details on how to add the plugin on your NOMAD instance.
 
-You don't need to modify the ```nomad.yaml``` configuration file of your NOMAD instance, beacuse the package is pip installed and all the available modules (entry points) are loaded.
+You don't need to modify the ```nomad.yaml``` configuration file of your NOMAD instance, because the package is pip installed and all the available modules (entry points) are loaded.
 To include, instead, only some of the entry points, you need to specify them in the ```include``` section of the ```nomad.yaml```. In the following lines, a list of all the available entry points:
 
 ```yaml
@@ -51,6 +51,18 @@ plugins:
     - "nomad_measurements.quantumdesign:acms_parser"
     - "nomad_measurements.quantumdesign:sequence_parser"
  ```
+
+X-ray diffraction ELN allows to generate a nexus `.nxs` file from the entry data by clicking on `Switch To/From HDF5 Results` button. This is useful for high-resolution or RSM scans, where the data is large and slows down the interaction with the entry. Once the data is moved to a nexus file, the entry only stores references to it, rather than the data itself, making the ELNs responsive. However, this requires that the plugin is installed with nexus dependencies. When adding this plugin to your oasis, nexus dependencies can be included by adding the following line in the `pyproject.toml`:
+
+```toml
+...
+dependencies = [
+  ...
+  "nomad-measurements[nexus]",
+]
+```
+
+If the nexus dependencies are not included, the functionality above still works but uses a plain `.h5` file rather than a `.nxs` file.
 
 
 ### Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ maintainers = [
 license = { file = "LICENSE" }
 dependencies = [
     "nomad-lab>=1.3.16",
-    "pynxtools>=0.10.0",
     "fairmat-readers-xrd>=0.0.7",
     "fairmat-readers-transmission>=0.0.2",
 ]
@@ -47,6 +46,7 @@ dependencies = [
 index-url = "https://gitlab.mpcdf.mpg.de/api/v4/projects/2187/packages/pypi/simple"
 
 [project.optional-dependencies]
+nexus = ["pynxtools>=0.10.0"]
 dev = [
     "pytest",
     "ruff",

--- a/src/nomad_measurements/utils.py
+++ b/src/nomad_measurements/utils.py
@@ -38,7 +38,9 @@ from nomad.units import ureg
 from pydantic import BaseModel, Field
 
 try:
-    import pynxtools.dataconverter as pynxtools_dataconverter
+    from pynxtools.dataconverter import helpers as pnx_helpers
+    from pynxtools.dataconverter import template as pnx_template
+    from pynxtools.dataconverter import writer as pnx_writer
 except ImportError:
     pass  # pynxtools is an optional dependency
 
@@ -399,11 +401,9 @@ class HDF5Handler:
         """
 
         app_def = self.nexus_dataset_map.get('/ENTRY[entry]/definition')
-        nxdl_root, nxdl_f_path = pynxtools_dataconverter.helpers.get_nxdl_root_and_path(
-            app_def
-        )
-        template = pynxtools_dataconverter.template.Template()
-        pynxtools_dataconverter.helpers.generate_template_from_nxdl(nxdl_root, template)
+        nxdl_root, nxdl_f_path = pnx_helpers.get_nxdl_root_and_path(app_def)
+        template = pnx_template.Template()
+        pnx_helpers.generate_template_from_nxdl(nxdl_root, template)
         attr_dict = {}
         dataset_dict = {}
         self._populate_nx_dataset_and_attribute(
@@ -441,7 +441,7 @@ class HDF5Handler:
                 self.archive.m_context.local_dir, self.filename
             )
 
-        pynxtools_dataconverter.writer.Writer(
+        pnx_writer.Writer(
             data=template, nxdl_f_path=nxdl_f_path, output_path=nx_full_file_path
         ).write()
         if isinstance(self.archive.m_context, ServerContext):

--- a/src/nomad_measurements/utils.py
+++ b/src/nomad_measurements/utils.py
@@ -39,7 +39,7 @@ from pydantic import BaseModel, Field
 
 try:
     import pynxtools.dataconverter as pynxtools_dataconverter
-except ImportError as e:
+except ImportError:
     pass  # pynxtools is an optional dependency
 
 if TYPE_CHECKING:

--- a/src/nomad_measurements/utils.py
+++ b/src/nomad_measurements/utils.py
@@ -36,12 +36,11 @@ from nomad.datamodel.hdf5 import HDF5Reference
 from nomad.datamodel.util import parse_path
 from nomad.units import ureg
 from pydantic import BaseModel, Field
-from pynxtools.dataconverter.helpers import (
-    generate_template_from_nxdl,
-    get_nxdl_root_and_path,
-)
-from pynxtools.dataconverter.template import Template
-from pynxtools.dataconverter.writer import Writer as pynxtools_writer
+
+try:
+    import pynxtools.dataconverter as pynxtools_dataconverter
+except ImportError as e:
+    pass  # pynxtools is an optional dependency
 
 if TYPE_CHECKING:
     from nomad.datamodel.data import (
@@ -361,12 +360,20 @@ class HDF5Handler:
         if self.nexus_dataset_map and not self._nexus_generation_error:
             try:
                 self._write_nx_file()
-            except Exception as e:
-                self._nexus_generation_error = True
+            except NameError:
                 self.logger.warning(
-                    f'NeXusFileGenerationError: Encountered "{e}" error while creating '
-                    '.nxs file. Creating .h5 file instead.'
+                    'The required "pynxtools" package for creating auxiliary .nxs '
+                    'files is not installed. Creating .h5 file instead.',
+                    exc_info=True,
                 )
+            except Exception:
+                self.logger.warning(
+                    'Encountered error while creating .nxs file. Creating .h5 file '
+                    'instead.',
+                    exc_info=True,
+                )
+            finally:
+                self._nexus_generation_error = False
                 self._write_hdf5_file()
         else:
             self._write_hdf5_file()
@@ -392,9 +399,11 @@ class HDF5Handler:
         """
 
         app_def = self.nexus_dataset_map.get('/ENTRY[entry]/definition')
-        nxdl_root, nxdl_f_path = get_nxdl_root_and_path(app_def)
-        template = Template()
-        generate_template_from_nxdl(nxdl_root, template)
+        nxdl_root, nxdl_f_path = pynxtools_dataconverter.helpers.get_nxdl_root_and_path(
+            app_def
+        )
+        template = pynxtools_dataconverter.template.Template()
+        pynxtools_dataconverter.helpers.generate_template_from_nxdl(nxdl_root, template)
         attr_dict = {}
         dataset_dict = {}
         self._populate_nx_dataset_and_attribute(
@@ -432,7 +441,7 @@ class HDF5Handler:
                 self.archive.m_context.local_dir, self.filename
             )
 
-        pynxtools_writer(
+        pynxtools_dataconverter.writer.Writer(
             data=template, nxdl_f_path=nxdl_f_path, output_path=nx_full_file_path
         ).write()
         if isinstance(self.archive.m_context, ServerContext):

--- a/src/nomad_measurements/utils.py
+++ b/src/nomad_measurements/utils.py
@@ -360,20 +360,20 @@ class HDF5Handler:
         if self.nexus_dataset_map and not self._nexus_generation_error:
             try:
                 self._write_nx_file()
-            except NameError:
-                self.logger.warning(
-                    'The required "pynxtools" package for creating auxiliary .nxs '
-                    'files is not installed. Creating .h5 file instead.',
-                    exc_info=True,
-                )
-            except Exception:
-                self.logger.warning(
-                    'Encountered error while creating .nxs file. Creating .h5 file '
-                    'instead.',
-                    exc_info=True,
-                )
-            finally:
-                self._nexus_generation_error = False
+            except Exception as e:
+                if isinstance(e, NameError):
+                    self.logger.warning(
+                        'The required "pynxtools" package for creating auxiliary .nxs '
+                        'files is not installed. Creating .h5 file instead.',
+                        exc_info=True,
+                    )
+                else:
+                    self.logger.warning(
+                        'Encountered error while creating .nxs file. Creating .h5 file '
+                        'instead.',
+                        exc_info=True,
+                    )
+                self._nexus_generation_error = True
                 self._write_hdf5_file()
         else:
             self._write_hdf5_file()

--- a/tests/test_xrd.py
+++ b/tests/test_xrd.py
@@ -23,6 +23,13 @@ from nomad.config import config
 
 from nomad_measurements.xrd.schema import XRDResult1D, XRDResult1DHDF5
 
+try:
+    import pynxtools  # noqa F401
+
+    HAS_PYNXTOOLS = True
+except ImportError:
+    HAS_PYNXTOOLS = False
+
 test_files = [
     'tests/data/xrd/XRD-918-16_10.xrdml',
     'tests/data/xrd/m54313_om2th_10.xrdml',
@@ -77,6 +84,7 @@ test_files = [
 ]
 
 
+@pytest.mark.skipif(not HAS_PYNXTOOLS, reason='pynxtools is not installed')
 @pytest.mark.parametrize(
     'parsed_measurement_archive, caplog',
     [((file, clean_up_extensions), log_levels) for file in test_files],


### PR DESCRIPTION
Moves `pynxtools` into an optional dependency table. In XRD schemas, when a user switches to the HDF5 results section, the normalizer writes a nexus file, populates the scan data, and saves references to the HDF5 datasets in the entry.

With this PR, the plugins needs to be installed with `nexus` optional dependency table in order to create nexus files. By default, a plain `.h5` file will be created in the above situation.

When adding this plugin to your oasis, nexus dependencies can be included by adding the following line in the `pyproject.toml`:
```toml
...
dependencies = [
  ...
  "nomad-measurements[nexus]",
]
```