### PR TITLE
Extend support for xrd scans on other position axes

### DIFF
--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -2010,6 +2010,7 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
                 return
             if schema_config.use_hdf5_results and scan_type == 'line':
                 self.results = [XRDResult1DHDF5()]
+                self.trigger_update_nexus_file = True
             elif not schema_config.use_hdf5_results and scan_type == 'line':
                 self.results = [XRDResult1D()]
             elif schema_config.use_hdf5_results and scan_type == 'rsm':
@@ -2017,7 +2018,6 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
                 self.trigger_update_nexus_file = True
             elif not schema_config.use_hdf5_results and scan_type == 'rsm':
                 self.results = [XRDResultRSM()]
-                self.trigger_update_nexus_file = True
         elif self.trigger_switch_results_section:
             try:
                 self.switch_results_section()

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -605,146 +605,72 @@ class XRDResult1D(XRDResult):
             (dict, dict): line_linear, line_log
         """
         plots = []
-        if self.two_theta is None or self.intensity is None:
+        if self.intensity is None:
             return plots
 
-        x = self.two_theta.to('degree').magnitude
         y = self.intensity.magnitude
 
-        fig_line_linear = px.line(
-            x=x,
-            y=y,
-        )
-        fig_line_linear.update_layout(
-            title={
-                'text': '<i>Intensity</i> over 2<i>θ</i> (linear scale)',
-                'x': 0.5,
-                'xanchor': 'center',
-            },
-            xaxis_title='2<i>θ</i> (°)',
-            yaxis_title='<i>Intensity</i>',
-            xaxis=dict(
-                fixedrange=False,
-            ),
-            yaxis=dict(
-                fixedrange=False,
-            ),
-            template='plotly_white',
-            hovermode='closest',
-            hoverlabel=dict(
-                bgcolor='white',
-            ),
-            dragmode='zoom',
-            width=600,
-            height=600,
-        )
-        fig_line_linear.update_traces(
-            hovertemplate='<i>Intensity</i>: %{y:.2f}<br>2<i>θ</i>: %{x}°',
-        )
-        plot_json = fig_line_linear.to_plotly_json()
-        plot_json['config'] = dict(
-            scrollZoom=False,
-        )
-        plots.append(
-            PlotlyFigure(
-                label='Intensity over 2θ (linear scale)',
-                index=1,
-                figure=plot_json,
+        position_labels = {
+            'two_theta': '2θ',
+            'omega': 'ω',
+            'phi': 'φ',
+            'chi': 'χ',
+            'q_norm': '|q|',
+        }
+
+        for position in ['two_theta', 'omega', 'phi', 'chi', 'q_norm']:
+            position_label = position_labels[position]
+            unit_label = '(°)' if position != 'q_norm' else '(Å⁻¹)'
+            if getattr(self, position) is None:
+                continue
+            x = (
+                getattr(self, position).to('degree').magnitude
+                if position != 'q_norm'
+                else getattr(self, position).to('1/angstrom').magnitude
             )
-        )
-
-        fig_line_log = px.line(
-            x=x,
-            y=y,
-            log_y=True,
-        )
-        fig_line_log.update_layout(
-            title={
-                'text': '<i>Intensity</i> over 2<i>θ</i> (log scale)',
-                'x': 0.5,
-                'xanchor': 'center',
-            },
-            xaxis_title='2<i>θ</i> (°)',
-            yaxis_title='<i>Intensity</i>',
-            xaxis=dict(
-                fixedrange=False,
-            ),
-            yaxis=dict(
-                fixedrange=False,
-            ),
-            template='plotly_white',
-            hovermode='closest',
-            hoverlabel=dict(
-                bgcolor='white',
-            ),
-            dragmode='zoom',
-            width=600,
-            height=600,
-        )
-        fig_line_log.update_traces(
-            hovertemplate='<i>Intensity</i>: %{y:.2f}<br>2<i>θ</i>: %{x}°',
-        )
-        plot_json = fig_line_log.to_plotly_json()
-        plot_json['config'] = dict(
-            scrollZoom=False,
-        )
-        plots.append(
-            PlotlyFigure(
-                label='Intensity over 2θ (log scale)',
-                index=0,
-                figure=plot_json,
-            )
-        )
-
-        if self.q_norm is None:
-            return plots
-
-        x = self.q_norm.to('1/angstrom').magnitude
-        fig_line_log = px.line(
-            x=x,
-            y=y,
-            log_y=True,
-        )
-        fig_line_log.update_layout(
-            title={
-                'text': '<i>Intensity</i> over |<em>q</em>| (log scale)',
-                'x': 0.5,
-                'xanchor': 'center',
-            },
-            xaxis_title='|<em>q</em>| (Å<sup>-1</sup>)',
-            yaxis_title='<i>Intensity</i>',
-            xaxis=dict(
-                fixedrange=False,
-            ),
-            yaxis=dict(
-                fixedrange=False,
-            ),
-            template='plotly_white',
-            hovermode='closest',
-            hoverlabel=dict(
-                bgcolor='white',
-            ),
-            dragmode='zoom',
-            width=600,
-            height=600,
-        )
-        fig_line_log.update_traces(
-            hovertemplate=(
-                '<i>Intensity</i>: %{y:.2f}<br>|<em>q</em>|: %{x} Å<sup>-1</sup>'
-            ),
-        )
-        plot_json = fig_line_log.to_plotly_json()
-        plot_json['config'] = dict(
-            scrollZoom=False,
-        )
-        plots.append(
-            PlotlyFigure(
-                label='Intensity over q_norm (log scale)',
-                index=2,
-                figure=plot_json,
-            )
-        )
-
+            if len(x) != len(y):
+                continue
+            for scale in ['linear', 'log']:
+                fig_line = px.line(x=x, y=y, log_y=(scale == 'log'))
+                fig_line.update_layout(
+                    title={
+                        'text': f'<i>Intensity</i> over <i>{position_label}</i> '
+                        f'({scale} scale)',
+                        'x': 0.5,
+                        'xanchor': 'center',
+                    },
+                    xaxis_title=f'<i>{position_label}</i> {unit_label}',
+                    yaxis_title='<i>Intensity</i>',
+                    xaxis=dict(
+                        fixedrange=False,
+                    ),
+                    yaxis=dict(
+                        fixedrange=False,
+                    ),
+                    template='plotly_white',
+                    hovermode='closest',
+                    hoverlabel=dict(
+                        bgcolor='white',
+                    ),
+                    dragmode='zoom',
+                    width=600,
+                    height=600,
+                )
+                fig_line.update_traces(
+                    hovertemplate=f'<i>Intensity</i>: %{{y:.3f}}<br>'
+                    f'<i>{position_label}</i>: %{{x:.3f}} {unit_label}',
+                )
+                plot_json = fig_line.to_plotly_json()
+                plot_json['config'] = dict(
+                    scrollZoom=False,
+                )
+                plots.append(
+                    PlotlyFigure(
+                        label=f'Intensity over {position} ({scale} scale)',
+                        index=0,
+                        figure=plot_json,
+                    )
+                )
         return plots
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -309,26 +309,32 @@ class IntensityPlot(ArchiveSection):
         description='The chi range of the diffractogram',
     )
 
-    def generate_hdf5_plots(self, hdf5_handler: HDF5Handler):
+    def generate_hdf5_plots(
+        self, hdf5_handler: HDF5Handler, plotting_position: str = 'two_theta'
+    ):
         """
         Add datasets and attributes to the HDF5 file for plotting the intensity over
         available positions.
 
         Args:
             hdf5_handler (HDF5Handler): The handler for the HDF5 file.
+            plotting_position (str): The position to be used for plotting the intensity.
+                Should be one of 'two_theta', 'omega', 'phi', or 'chi'.
         """
         prefix = '/ENTRY[entry]/experiment_result'
 
         intensity = hdf5_handler.read_dataset(path=f'{prefix}/intensity')
-        two_theta = hdf5_handler.read_dataset(path=f'{prefix}/two_theta')
-        if intensity is None or two_theta is None:
+        position_data = hdf5_handler.read_dataset(
+            path=f'/ENTRY[entry]/experiment_result/{plotting_position}'
+        )
+        if intensity is None or position_data is None:
             return
 
         hdf5_handler.add_dataset(
-            path=f'{prefix}/intensity_plot/two_theta',
+            path=f'{prefix}/intensity_plot/{plotting_position}',
             dataset=Dataset(
-                data=f'{prefix}/two_theta',
-                archive_path='data.results[0].intensity_plot.two_theta',
+                data=f'{prefix}/{plotting_position}',
+                archive_path=f'data.results[0].intensity_plot.{plotting_position}',
                 internal_reference=True,
             ),
             validate_path=False,
@@ -342,40 +348,48 @@ class IntensityPlot(ArchiveSection):
             ),
             validate_path=False,
         )
-        hdf5_handler.add_attribute(
-            path=f'{prefix}/intensity_plot',
-            params=dict(
-                axes='two_theta',
-                signal='intensity',
-                NX_class='NXdata',
-            ),
-        )
+
         if isinstance(self.m_parent, XRDResult1DHDF5):
+            if position_data.shape != intensity.shape:
+                return
+            hdf5_handler.add_attribute(
+                path=f'{prefix}/intensity_plot',
+                params=dict(
+                    axes=plotting_position,
+                    signal='intensity',
+                    NX_class='NXdata',
+                ),
+            )
             return
 
-        for var_axis in ['omega', 'phi', 'chi']:
-            var_axis_data = hdf5_handler.read_dataset(
-                path=f'/ENTRY[entry]/experiment_result/{var_axis}'
-            )
-            if var_axis_data is not None:
-                hdf5_handler.add_dataset(
-                    path=f'{prefix}/intensity_plot/{var_axis}',
-                    dataset=Dataset(
-                        data=f'{prefix}/{var_axis}',
-                        archive_path=f'data.results[0].intensity_plot.{var_axis}',
-                        internal_reference=True,
-                    ),
-                    validate_path=False,
+        # RSM scan plots: Add another axis and plot
+        if (
+            isinstance(self.m_parent, XRDResultRSMHDF5)
+            and plotting_position == 'two_theta'
+        ):
+            for var_axis in ['omega', 'phi', 'chi']:
+                var_axis_data = hdf5_handler.read_dataset(
+                    path=f'/ENTRY[entry]/experiment_result/{var_axis}'
                 )
-                hdf5_handler.add_attribute(
-                    path=f'{prefix}/intensity_plot',
-                    params=dict(
-                        axes=[var_axis, 'two_theta'],
-                        signal='intensity',
-                        NX_class='NXdata',
-                    ),
-                )
-                break
+                if var_axis_data is not None:
+                    hdf5_handler.add_dataset(
+                        path=f'{prefix}/intensity_plot/{var_axis}',
+                        dataset=Dataset(
+                            data=f'{prefix}/{var_axis}',
+                            archive_path=f'data.results[0].intensity_plot.{var_axis}',
+                            internal_reference=True,
+                        ),
+                        validate_path=False,
+                    )
+                    hdf5_handler.add_attribute(
+                        path=f'{prefix}/intensity_plot',
+                        params=dict(
+                            axes=['two_theta', var_axis],
+                            signal='intensity',
+                            NX_class='NXdata',
+                        ),
+                    )
+                    break
 
 
 class IntensityScatteringVectorPlot(ArchiveSection):
@@ -429,6 +443,8 @@ class IntensityScatteringVectorPlot(ArchiveSection):
             return
 
         if q_norm is not None:
+            if intensity.shape != q_norm.shape:
+                return
             hdf5_handler.add_dataset(
                 path=f'{prefix}/intensity_scattering_vector_plot/intensity',
                 dataset=Dataset(
@@ -592,14 +608,13 @@ class XRDResult1D(XRDResult):
         )
     )
 
-    def generate_plots(self):
+    def generate_plots(self, plotting_position: str = 'two_theta'):
         """
         Plot the 1D diffractogram.
 
         Args:
-            archive (EntryArchive): The archive containing the section that is being
-            normalized.
-            logger (BoundLogger): A structlog logger.
+            plotting_position (str): The position to be used for plotting the intensity.
+                Should be one of 'two_theta', 'omega', 'phi', 'chi'.
 
         Returns:
             (dict, dict): line_linear, line_log
@@ -607,9 +622,7 @@ class XRDResult1D(XRDResult):
         plots = []
         if self.intensity is None:
             return plots
-
         y = self.intensity.magnitude
-
         position_labels = {
             'two_theta': '2θ',
             'omega': 'ω',
@@ -617,8 +630,11 @@ class XRDResult1D(XRDResult):
             'chi': 'χ',
             'q_norm': '|q|',
         }
+        positions_for_plotting = [plotting_position]
+        if plotting_position == 'two_theta':
+            positions_for_plotting.append('q_norm')
 
-        for position in ['two_theta', 'omega', 'phi', 'chi', 'q_norm']:
+        for position in positions_for_plotting:
             position_label = position_labels[position]
             unit_label = '(°)' if position != 'q_norm' else '(Å⁻¹)'
             if getattr(self, position) is None:
@@ -1173,7 +1189,9 @@ class XRDResult1DHDF5(XRDResult):
                 ),
             )
 
-    def generate_hdf5_plots(self, hdf5_handler: HDF5Handler):
+    def generate_hdf5_plots(
+        self, hdf5_handler: HDF5Handler, plotting_position: str = 'two_theta'
+    ):
         """
         Initializes sections to generate the plots for intensity over position and
         scattering vectors.
@@ -1184,7 +1202,7 @@ class XRDResult1DHDF5(XRDResult):
         if hdf5_handler is None:
             return
         self.m_setdefault('intensity_plot')
-        self.intensity_plot.generate_hdf5_plots(hdf5_handler)
+        self.intensity_plot.generate_hdf5_plots(hdf5_handler, plotting_position)
 
         if self.source_peak_wavelength is not None:
             self.m_setdefault('intensity_scattering_vector_plot')
@@ -1793,6 +1811,103 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
             self.auxiliary_file = None
             self.nexus_view = None
 
+    def populate_measurement_results_hdf5(
+        self,
+        result_dict: dict,
+        plotting_position: str,
+        archive: 'EntryArchive',
+        logger: 'BoundLogger',
+    ):
+        """
+        Populate the results section of the X-ray diffraction data for HDF5 results
+        section. It updates the HDF5 file with the new data and generates the plots.
+
+        Args:
+            result_dict (Dict): The result data dictionary.
+            plotting_position (str): The position to be used for plotting line scans.
+            archive (EntryArchive): The archive containing the section.
+            logger (BoundLogger): A structlog logger.
+        """
+        filename = self.data_file.rsplit('.', 1)[0]
+        self.auxiliary_file = (
+            f'{filename}.h5'
+            if archive.m_context.raw_path_exists(f'{filename}.h5')
+            else f'{filename}.nxs'
+        )
+        self.hdf5_handler = HDF5Handler(
+            filename=self.auxiliary_file,
+            archive=archive,
+            logger=logger,
+        )
+        if self.auxiliary_file.endswith('.nxs'):
+            self.hdf5_handler.nexus_dataset_map = NEXUS_DATASET_MAP
+
+        self.hdf5_handler.add_dataset(
+            path='/ENTRY[entry]/experiment_result/intensity',
+            dataset=Dataset(
+                data=result_dict.get('intensity'),
+                archive_path='data.results[0].intensity',
+            ),
+        )
+        self.hdf5_handler.add_dataset(
+            path='/ENTRY[entry]/experiment_result/two_theta',
+            dataset=Dataset(
+                data=result_dict.get('two_theta'),
+                archive_path='data.results[0].two_theta',
+            ),
+        )
+        self.hdf5_handler.add_dataset(
+            path='/ENTRY[entry]/experiment_result/omega',
+            dataset=Dataset(
+                data=result_dict.get('omega'),
+                archive_path='data.results[0].omega',
+            ),
+        )
+        self.hdf5_handler.add_dataset(
+            path='/ENTRY[entry]/experiment_result/chi',
+            dataset=Dataset(
+                data=result_dict.get('chi'),
+                archive_path='data.results[0].chi',
+            ),
+        )
+        self.hdf5_handler.add_dataset(
+            path='/ENTRY[entry]/experiment_result/phi',
+            dataset=Dataset(
+                data=result_dict.get('phi'),
+                archive_path='data.results[0].phi',
+            ),
+        )
+        self.hdf5_handler.add_dataset(
+            path='/ENTRY[entry]/experiment_config/count_time',
+            dataset=Dataset(
+                data=result_dict.get('integration_time'),
+                archive_path='data.results[0].integration_time',
+            ),
+        )
+        self.results[0].scan_axis = result_dict.get('scan_axis')
+        self.results[0].source_peak_wavelength = result_dict.get(
+            'source_peak_wavelength'
+        )
+        self.results[0].calculate_scattering_vectors(self.hdf5_handler)
+        if isinstance(self.results[0], XRDResult1DHDF5):
+            result: XRDResult1DHDF5 = self.results[0]
+            result.generate_hdf5_plots(self.hdf5_handler, plotting_position)
+        else:
+            result: XRDResultRSMHDF5 = self.results[0]
+            result.generate_hdf5_plots(self.hdf5_handler)
+        self.results[0].normalize(archive, logger)
+
+        self.hdf5_handler.write_file()
+
+        if self.hdf5_handler.filename != self.auxiliary_file:
+            self.auxiliary_file = self.hdf5_handler.filename
+        self.nexus_view = None
+        if self.auxiliary_file.endswith('.nxs'):
+            nx_entry_id = get_entry_id_from_file_name(
+                archive=archive, file_name=self.auxiliary_file
+            )
+            self.nexus_view = get_reference(archive.metadata.upload_id, nx_entry_id)
+
     def populate_measurement_results(
         self, xrd_dict: dict, archive: 'EntryArchive', logger: 'BoundLogger'
     ):
@@ -1817,6 +1932,14 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
             phi=xrd_dict.get('Phi'),
             integration_time=xrd_dict.get('countTime'),
         )
+        plotting_position = None
+        if isinstance(self.results[0], (XRDResult1D, XRDResult1DHDF5)):
+            for position in ['two_theta', 'omega', 'chi', 'phi']:
+                if result_dict[position].shape == result_dict['intensity'].shape:
+                    plotting_position = position
+                    break
+            if plotting_position is None:
+                raise AssertionError('Cannot determine plotting position for 1D scan.')
         if (
             self.xrd_settings is not None
             and self.xrd_settings.source is not None
@@ -1829,87 +1952,24 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
                 if v is not None:
                     setattr(self.results[0], k, v)
             self.results[0].normalize(archive, logger)
-            self.figures = self.results[0].generate_plots()
-        elif (
+            if isinstance(self.results[0], XRDResult1D):
+                result: XRDResult1D = self.results[0]
+                self.figures = result.generate_plots(
+                    plotting_position=plotting_position
+                )
+            elif isinstance(self.results[0], XRDResultRSM):
+                result: XRDResultRSM = self.results[0]
+                self.figures = result.generate_plots()
+        if (
             isinstance(self.results[0], XRDResult1DHDF5 | XRDResultRSMHDF5)
             and self.trigger_update_nexus_file
         ):
-            filename = self.data_file.rsplit('.', 1)[0]
-            self.auxiliary_file = (
-                f'{filename}.h5'
-                if archive.m_context.raw_path_exists(f'{filename}.h5')
-                else f'{filename}.nxs'
-            )
-            self.hdf5_handler = HDF5Handler(
-                filename=self.auxiliary_file,
-                archive=archive,
-                logger=logger,
-            )
-            if self.auxiliary_file.endswith('.nxs'):
-                self.hdf5_handler.nexus_dataset_map = NEXUS_DATASET_MAP
-
-            self.hdf5_handler.add_dataset(
-                path='/ENTRY[entry]/experiment_result/intensity',
-                dataset=Dataset(
-                    data=xrd_dict.get('intensity'),
-                    archive_path='data.results[0].intensity',
-                ),
-            )
-            self.hdf5_handler.add_dataset(
-                path='/ENTRY[entry]/experiment_result/two_theta',
-                dataset=Dataset(
-                    data=xrd_dict.get('2Theta'),
-                    archive_path='data.results[0].two_theta',
-                ),
-            )
-            self.hdf5_handler.add_dataset(
-                path='/ENTRY[entry]/experiment_result/omega',
-                dataset=Dataset(
-                    data=xrd_dict.get('Omega'),
-                    archive_path='data.results[0].omega',
-                ),
-            )
-            self.hdf5_handler.add_dataset(
-                path='/ENTRY[entry]/experiment_result/chi',
-                dataset=Dataset(
-                    data=xrd_dict.get('Chi'),
-                    archive_path='data.results[0].chi',
-                ),
-            )
-            self.hdf5_handler.add_dataset(
-                path='/ENTRY[entry]/experiment_result/phi',
-                dataset=Dataset(
-                    data=xrd_dict.get('Phi'),
-                    archive_path='data.results[0].phi',
-                ),
-            )
-            self.hdf5_handler.add_dataset(
-                path='/ENTRY[entry]/experiment_config/count_time',
-                dataset=Dataset(
-                    data=xrd_dict.get('countTime'),
-                    archive_path='data.results[0].integration_time',
-                ),
-            )
-            self.results[0].scan_axis = result_dict.get('scan_axis')
-            self.results[0].source_peak_wavelength = result_dict.get(
-                'source_peak_wavelength'
-            )
-            self.results[0].calculate_scattering_vectors(self.hdf5_handler)
-            self.results[0].generate_hdf5_plots(self.hdf5_handler)
-            self.results[0].normalize(archive, logger)
-
-            self.hdf5_handler.write_file()
-
-            if self.hdf5_handler.filename != self.auxiliary_file:
-                self.auxiliary_file = self.hdf5_handler.filename
-            self.nexus_view = None
-            if self.auxiliary_file.endswith('.nxs'):
-                nx_entry_id = get_entry_id_from_file_name(
-                    archive=archive, file_name=self.auxiliary_file
+            try:
+                self.populate_measurement_results_hdf5(
+                    result_dict, plotting_position, archive, logger
                 )
-                self.nexus_view = get_reference(archive.metadata.upload_id, nx_entry_id)
-
-        self.trigger_update_nexus_file = False
+            finally:
+                self.trigger_update_nexus_file = False
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
         """
@@ -1949,8 +2009,10 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
                 self.results = [XRDResultRSM()]
             self.trigger_update_nexus_file = True
         elif self.trigger_switch_results_section:
-            self.switch_results_section()
-            self.trigger_switch_results_section = False
+            try:
+                self.switch_results_section()
+            finally:
+                self.trigger_switch_results_section = False
 
         # populate the measurement results section
         self.populate_measurement_results(xrd_dict, archive, logger)

--- a/src/nomad_measurements/xrd/schema.py
+++ b/src/nomad_measurements/xrd/schema.py
@@ -384,7 +384,7 @@ class IntensityPlot(ArchiveSection):
                     hdf5_handler.add_attribute(
                         path=f'{prefix}/intensity_plot',
                         params=dict(
-                            axes=['two_theta', var_axis],
+                            axes=[var_axis, 'two_theta'],
                             signal='intensity',
                             NX_class='NXdata',
                         ),
@@ -634,6 +634,7 @@ class XRDResult1D(XRDResult):
         if plotting_position == 'two_theta':
             positions_for_plotting.append('q_norm')
 
+        plot_index = 0
         for position in positions_for_plotting:
             position_label = position_labels[position]
             unit_label = '(°)' if position != 'q_norm' else '(Å⁻¹)'
@@ -683,10 +684,11 @@ class XRDResult1D(XRDResult):
                 plots.append(
                     PlotlyFigure(
                         label=f'Intensity over {position} ({scale} scale)',
-                        index=0,
+                        index=plot_index,
                         figure=plot_json,
                     )
                 )
+                plot_index += 1
         return plots
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
@@ -1198,6 +1200,8 @@ class XRDResult1DHDF5(XRDResult):
 
         Args:
             hdf5_handler (HDF5Handler): The handler for the HDF5 file.
+            plotting_position (str): The position to be used for plotting the intensity.
+                Should be one of 'two_theta', 'omega', 'phi', or 'chi'.
         """
         if hdf5_handler is None:
             return
@@ -1712,6 +1716,7 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
     )
     trigger_switch_results_section = Quantity(
         type=bool,
+        default=False,
         description="""
         Switches the results section. If it is a non-HDF5 section, it will be converted
         to HDF5 section (which uses NeXus file in the backend) and vice versa.
@@ -1722,6 +1727,7 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
     )
     trigger_update_nexus_file = Quantity(
         type=bool,
+        default=False,
         description="""
         Updates the nexus file with the current ELN state when using HDF5 results
         section.
@@ -1825,6 +1831,7 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
         Args:
             result_dict (Dict): The result data dictionary.
             plotting_position (str): The position to be used for plotting line scans.
+                Should be one of 'two_theta', 'omega', 'phi', or 'chi'.
             archive (EntryArchive): The archive containing the section.
             logger (BoundLogger): A structlog logger.
         """
@@ -1890,6 +1897,8 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
         )
         self.results[0].calculate_scattering_vectors(self.hdf5_handler)
         if isinstance(self.results[0], XRDResult1DHDF5):
+            if plotting_position is None:
+                raise AssertionError('Plotting position should not be None.')
             result: XRDResult1DHDF5 = self.results[0]
             result.generate_hdf5_plots(self.hdf5_handler, plotting_position)
         else:
@@ -1935,7 +1944,10 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
         plotting_position = None
         if isinstance(self.results[0], (XRDResult1D, XRDResult1DHDF5)):
             for position in ['two_theta', 'omega', 'chi', 'phi']:
-                if result_dict[position].shape == result_dict['intensity'].shape:
+                if (
+                    result_dict[position] is not None
+                    and result_dict[position].shape == result_dict['intensity'].shape
+                ):
                     plotting_position = position
                     break
             if plotting_position is None:
@@ -1960,16 +1972,13 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
             elif isinstance(self.results[0], XRDResultRSM):
                 result: XRDResultRSM = self.results[0]
                 self.figures = result.generate_plots()
-        if (
+        elif (
             isinstance(self.results[0], XRDResult1DHDF5 | XRDResultRSMHDF5)
             and self.trigger_update_nexus_file
         ):
-            try:
-                self.populate_measurement_results_hdf5(
-                    result_dict, plotting_position, archive, logger
-                )
-            finally:
-                self.trigger_update_nexus_file = False
+            self.populate_measurement_results_hdf5(
+                result_dict, plotting_position, archive, logger
+            )
 
     def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
         """
@@ -2005,9 +2014,10 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
                 self.results = [XRDResult1D()]
             elif schema_config.use_hdf5_results and scan_type == 'rsm':
                 self.results = [XRDResultRSMHDF5()]
+                self.trigger_update_nexus_file = True
             elif not schema_config.use_hdf5_results and scan_type == 'rsm':
                 self.results = [XRDResultRSM()]
-            self.trigger_update_nexus_file = True
+                self.trigger_update_nexus_file = True
         elif self.trigger_switch_results_section:
             try:
                 self.switch_results_section()
@@ -2015,7 +2025,12 @@ class ELNXRayDiffraction(XRayDiffraction, EntryData, PlotSection):
                 self.trigger_switch_results_section = False
 
         # populate the measurement results section
-        self.populate_measurement_results(xrd_dict, archive, logger)
+        try:
+            self.populate_measurement_results(xrd_dict, archive, logger)
+        except Exception as e:
+            logger.error(f'Error populating measurement results: {e}')
+        finally:
+            self.trigger_update_nexus_file = False
 
         super().normalize(archive, logger)
 


### PR DESCRIPTION
The data for other position axes is already available in the results section. This PR refactors the code to generate plots of `omega`, `chi`, and `phi` scans (tried in that order) when the `two_theta` value is fixed.

- Add `plotting_position` to signature of `generate_plot` and `generate_hdf5_plots`, where required.
- Determines `plotting_position` based on the shape of intensity and given position. Tries in this order: two_theta, omega, chi, phi. Whichever matches the shape of the intensity is taken for generating plots. Only applies to line scans.
- Plot `q_norm` only when `two_theta` position is used for plotting.
- Refactors `ELNXRayDiffraction` normalization. 