### PR TITLE
Update `fairmat-readers-xrd` dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ maintainers = [
 license = { file = "LICENSE" }
 dependencies = [
     "nomad-lab>=1.3.16",
-    "fairmat-readers-xrd>=0.0.7",
+    "fairmat-readers-xrd>=0.0.8",
     "fairmat-readers-transmission>=0.0.2",
 ]
 [project.urls]


### PR DESCRIPTION
- Update the readers package to include Bruker `.raw` reader.