### PR TITLE
initial plugin metadata extraction

### DIFF
--- a/.metadata/nomad_plugin_metadata.auto.yaml
+++ b/.metadata/nomad_plugin_metadata.auto.yaml
@@ -1,0 +1,367 @@
+id: nomad-measurements
+metadata_schema_version: 1.0.0
+name: nomad-measurements
+description: A plugin for NOMAD containing base sections for measurements.
+license: LICENSE
+upstream_repository: https://github.com/FAIRmat-NFDI/nomad-measurements
+documentation: https://fairmat-nfdi.github.io/nomad-measurements/
+homepage: https://github.com/FAIRmat-NFDI/nomad-measurements
+issue_tracker: https://github.com/FAIRmat-NFDI/nomad-measurements/issues
+maintainers:
+- name: FAIRmat
+  email: fairmat@physik.hu-berlin.de
+authors:
+- name: Andrea Albino
+- name: "Sebastian Br\xFCckner"
+- name: Sarthak Kapoor
+- name: "Jos\xE9 A. M\xE1rquez"
+- name: Rubel Mozumder
+- name: "Hampus N\xE4sstr\xF6m"
+entry_points:
+- id: nomad.plugin:general_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: general_schema
+  python_object: nomad_measurements:schema_entry_point
+  capability_type: schema
+- id: nomad.plugin:xrd_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: xrd_schema
+  python_object: nomad_measurements.xrd:schema_entry_point
+  capability_type: schema
+- id: nomad.plugin:xrd_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: xrd_parser
+  python_object: nomad_measurements.xrd:parser_entry_point
+  capability_type: parser
+- id: nomad.plugin:qd_eto_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_eto_schema
+  python_object: nomad_measurements.quantumdesign:eto_schema
+  capability_type: schema
+- id: nomad.plugin:qd_act_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_act_schema
+  python_object: nomad_measurements.quantumdesign:act_schema
+  capability_type: schema
+- id: nomad.plugin:qd_acms_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_acms_schema
+  python_object: nomad_measurements.quantumdesign:acms_schema
+  capability_type: schema
+- id: nomad.plugin:qd_mpms_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_mpms_schema
+  python_object: nomad_measurements.quantumdesign:mpms_schema
+  capability_type: schema
+- id: nomad.plugin:qd_resisitivity_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_resisitivity_schema
+  python_object: nomad_measurements.quantumdesign:resistivity_schema
+  capability_type: schema
+- id: nomad.plugin:qd_eto_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_eto_parser
+  python_object: nomad_measurements.quantumdesign:eto_parser
+  capability_type: parser
+- id: nomad.plugin:qd_act_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_act_parser
+  python_object: nomad_measurements.quantumdesign:act_parser
+  capability_type: parser
+- id: nomad.plugin:qd_acms_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_acms_parser
+  python_object: nomad_measurements.quantumdesign:acms_parser
+  capability_type: parser
+- id: nomad.plugin:qd_mpms_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_mpms_parser
+  python_object: nomad_measurements.quantumdesign:mpms_parser
+  capability_type: parser
+- id: nomad.plugin:qd_resistivity_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_resistivity_parser
+  python_object: nomad_measurements.quantumdesign:resistivity_parser
+  capability_type: parser
+- id: nomad.plugin:qd_sequence_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_sequence_parser
+  python_object: nomad_measurements.quantumdesign:sequence_parser
+  capability_type: parser
+- id: nomad.plugin:transmission_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: transmission_schema
+  python_object: nomad_measurements.transmission:schema_entry_point
+  capability_type: schema
+- id: nomad.plugin:transmission_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: transmission_parser
+  python_object: nomad_measurements.transmission:parser_entry_point
+  capability_type: parser
+- id: nomad.plugin:mapping_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: mapping_schema
+  python_object: nomad_measurements.mapping:schema_entry_point
+  capability_type: schema
+capabilities:
+- id: general_schema
+  capability_type: schema
+  title: General Schema
+  summary: Schema package containing basic classes used around in the plugin.
+- id: xrd_schema
+  capability_type: schema
+  title: XRD Schema
+  summary: Schema for XRD FAIR data.
+- id: xrd_parser
+  capability_type: parser
+  title: XRD Parser
+  summary: Parser for several kinds of raw files from XRD measurements.
+  parser_details:
+    parser_name: XRD Parser
+    parser_level: 0
+    mainfile_name_re: ^.*\.xrdml$|^.*\.rasx$|^.*\.brml$|^.*\.raw$
+    mainfile_mime_re: text/.*|application/zip|application/octet-stream
+    mainfile_alternative: false
+- id: qd_eto_schema
+  capability_type: schema
+  title: PQD ETO Schema
+  summary: Schema for QD measurements done by the ETO option.
+- id: qd_act_schema
+  capability_type: schema
+  title: QD ACT Schema
+  summary: Schema for QD measurements done by the ACT option.
+- id: qd_acms_schema
+  capability_type: schema
+  title: QD ACMS Schema
+  summary: Schema for QD measurements done by the ACMS option.
+- id: qd_mpms_schema
+  capability_type: schema
+  title: QD MPMS Schema
+  summary: Schema for QD measurements done by the MPMS option.
+- id: qd_resisitivity_schema
+  capability_type: schema
+  title: QD Resistivity Schema
+  summary: Schema for QD measurements done by the Resistivity option.
+- id: qd_eto_parser
+  capability_type: parser
+  title: DataParser for QD ETO
+  summary: "Parser for QD data files created by the ETO option.\n        Parses files\
+    \ containing the 'BYAPP, Electrical Transport Option' line and\n        extracts\
+    \ resistivities, temperatures, fields, and other relevant data. "
+  parser_details:
+    parser_name: DataParser for QD ETO
+    parser_level: 0
+    mainfile_name_re: .+\.dat
+    mainfile_contents_re: BYAPP, Electrical Transport Option
+    mainfile_mime_re: text/plain|application/x-wine-extension-ini
+    mainfile_alternative: false
+- id: qd_act_parser
+  capability_type: parser
+  title: DataParser for QD ACT
+  summary: "Parser for QD data files created by the ACT option.\n        Parses files\
+    \ containing the 'BYAPP, ACTRANSPORT' (Alternating current\n        transport)\
+    \ line and extracts resistivities, temperatures, fields, and other\n        relevant\
+    \ data. "
+  parser_details:
+    parser_name: DataParser for QD ACT
+    parser_level: 0
+    mainfile_name_re: .+\.dat
+    mainfile_contents_re: BYAPP,\s*ACTRANSPORT
+    mainfile_mime_re: text/plain|application/x-wine-extension-ini
+    mainfile_alternative: false
+- id: qd_acms_parser
+  capability_type: parser
+  title: DataParser for QD ACMS
+  summary: 'Parser for QD data files created by the ACMS option.         Parses files
+    containing the ''BYAPP, ACMS'' (Alternating current magnetic        susceptibility)
+    line and extracts resistivities, temperatures, fields, and         other relevant
+    data. '
+  parser_details:
+    parser_name: DataParser for QD ACMS
+    parser_level: 0
+    mainfile_name_re: .+\.dat
+    mainfile_contents_re: BYAPP,\s*ACMS
+    mainfile_mime_re: text/plain|application/x-wine-extension-ini
+    mainfile_alternative: false
+- id: qd_mpms_parser
+  capability_type: parser
+  title: DataParser for QD MPMS
+  summary: "Parser for QD data files created by the MPMS option.\n        Parses files\
+    \ containing the 'BYAPP, MPMS' (Magnetic property measurement\n        system)\
+    \ line and extracts temperatures, fields, and other relevant data. "
+  parser_details:
+    parser_name: DataParser for QD MPMS
+    parser_level: 0
+    mainfile_name_re: .+\.dat
+    mainfile_contents_re: BYAPP,\s*MPMS
+    mainfile_mime_re: text/plain|application/x-wine-extension-ini
+    mainfile_alternative: false
+- id: qd_resistivity_parser
+  capability_type: parser
+  title: DataParser for QD Resistivity
+  summary: "Parser for QD data files created by the Resistivity option.\n        Parses\
+    \ files containing the 'BYAPP, Resistivity' line and extracts\n        resistivities,\
+    \ temperatures, fields, and other relevant data. "
+  parser_details:
+    parser_name: DataParser for QD Resistivity
+    parser_level: 0
+    mainfile_name_re: .+\.dat
+    mainfile_contents_re: BYAPP,\s*Resistivity
+    mainfile_mime_re: text/plain|application/x-wine-extension-ini
+    mainfile_alternative: false
+- id: qd_sequence_parser
+  capability_type: parser
+  title: QDSequenceParser
+  summary: Parser for QD sequence files.
+  parser_details:
+    parser_name: QDSequenceParser
+    parser_level: 0
+    mainfile_name_re: .+\.seq
+    mainfile_mime_re: text/plain
+    mainfile_alternative: false
+- id: transmission_schema
+  capability_type: schema
+  title: Transmission Schema
+  summary: Schema for data from Transmission Spectrophotometry.
+- id: transmission_parser
+  capability_type: parser
+  title: Transmission Parser
+  summary: "\n    Parser for data from Transmission Spectrophotometry measurements.\
+    \ Currently\n    supports `.asc` files generated by Perkin Elmer UV WinLab software.\n\
+    \    "
+  parser_details:
+    parser_name: Transmission Parser
+    parser_level: 0
+    mainfile_name_re: ^.*\.asc$
+    mainfile_contents_re: ^PE UV
+    mainfile_mime_re: text/.*|application/zip
+    mainfile_alternative: false
+- id: mapping_schema
+  capability_type: schema
+  title: Mapping Schema
+  summary: Schema package containing schemas for mapping measurements.
+supported_filetypes:
+- .xrdml
+- .rasx
+- .brml
+- .raw
+- .dat
+- .seq
+- .asc
+file_format_support:
+- id: xrdml
+  label: .xrdml
+  capability_id: xrd_parser
+  producer: xrd-parser
+  extensions:
+  - .xrdml
+  mime_types:
+  - text/.*|application/zip|application/octet-stream
+- id: rasx
+  label: .rasx
+  capability_id: xrd_parser
+  producer: xrd-parser
+  extensions:
+  - .rasx
+  mime_types:
+  - text/.*|application/zip|application/octet-stream
+- id: brml
+  label: .brml
+  capability_id: xrd_parser
+  producer: xrd-parser
+  extensions:
+  - .brml
+  mime_types:
+  - text/.*|application/zip|application/octet-stream
+- id: raw
+  label: .raw
+  capability_id: xrd_parser
+  producer: xrd-parser
+  extensions:
+  - .raw
+  mime_types:
+  - text/.*|application/zip|application/octet-stream
+- id: dat
+  label: .dat
+  capability_id: qd_eto_parser
+  producer: dataparser-for-qd-eto
+  extensions:
+  - .dat
+  mime_types:
+  - text/plain|application/x-wine-extension-ini
+- id: seq
+  label: .seq
+  capability_id: qd_sequence_parser
+  producer: qdsequenceparser
+  extensions:
+  - .seq
+  mime_types:
+  - text/plain
+- id: asc
+  label: .asc
+  capability_id: transmission_parser
+  producer: transmission-parser
+  extensions:
+  - .asc
+  mime_types:
+  - text/.*|application/zip
+schema_dependencies:
+- dependency_type: python_package
+  package_name: nomad-lab
+  version_range: '>=1.3.16'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: fairmat-readers-xrd
+  version_range: '>=0.0.8'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: fairmat-readers-transmission
+  version_range: '>=0.0.2'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: pynxtools
+  version_range: '>=0.10.0'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: ruff
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: structlog
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: python-logstash
+  version_range: '>=0.4.6'
+  optional: true
+  purpose: optional
+metadata_provenance:
+- source: pyproject
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:39:01.416619+00:00'
+  generator_version: 0.1.0
+- source: plugin_entry_points
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:39:01.416660+00:00'
+  generator_version: 0.1.0
+- source: citation_cff
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:39:01.416676+00:00'
+  generator_version: 0.1.0
+stars: 15
+owner: FAIRmat-NFDI
+owner_type: Organization
+created: '2023-09-06T10:00:22Z'
+last_updated: '2026-01-07T14:47:20Z'
+archived: false

--- a/.metadata/nomad_plugin_metadata.auto.yaml
+++ b/.metadata/nomad_plugin_metadata.auto.yaml
@@ -349,15 +349,15 @@ schema_dependencies:
 metadata_provenance:
 - source: pyproject
   extraction_method: deterministic
-  generated_at: '2026-03-19T14:39:01.416619+00:00'
+  generated_at: '2026-03-19T14:51:28.256431+00:00'
   generator_version: 0.1.0
 - source: plugin_entry_points
   extraction_method: deterministic
-  generated_at: '2026-03-19T14:39:01.416660+00:00'
+  generated_at: '2026-03-19T14:51:28.256467+00:00'
   generator_version: 0.1.0
 - source: citation_cff
   extraction_method: deterministic
-  generated_at: '2026-03-19T14:39:01.416676+00:00'
+  generated_at: '2026-03-19T14:51:28.256481+00:00'
   generator_version: 0.1.0
 stars: 15
 owner: FAIRmat-NFDI

--- a/.metadata/nomad_plugin_metadata.manual.yaml
+++ b/.metadata/nomad_plugin_metadata.manual.yaml
@@ -1,0 +1,120 @@
+# Maintainer-owned metadata overrides and manual additions.
+# This file is never machine-overwritten after creation.
+# Use null/empty values as placeholders; only non-empty values override auto output.
+# list[str] domain/topic tags (e.g. "simulations", "spectroscopy")
+subject:
+  - measurements
+  - xrd
+  - transport
+  - magnetometry
+  - spectroscopy
+# enum {alpha, beta, stable, archived}
+maturity: stable
+# str, e.g. "main"
+repository_default_branch: main
+
+# Deployment flags.
+deployment:
+  # boolean
+  on_central: false
+  # boolean
+  on_example_oasis: true
+  # boolean
+  on_pypi: true
+  # str (PyPI package name)
+  pypi_package: nomad-measurements
+
+# Suggested usages for registry filtering/discovery.
+suggested_usages:
+  -
+    # str (stable ID slug), e.g. "parse-xrd-patterns"
+    id: parse-xrd-raw-files
+    # str
+    title: Parse XRD raw files
+    # str (what user wants to do), e.g. "Import and parse raw files"
+    user_intent: Import powder XRD raw outputs into NOMAD
+    # enum {simulations, measurements, synthesis, cross-domain, workflow, infrastructure}
+    domain_category: measurements
+    # str, e.g. "XRD", "DFT"
+    technique: xrd
+    # str, e.g. "beginner", "expert"
+    audience: intermediate
+    # enum {alpha, beta, stable, archived}
+    maturity: stable
+    # list[str]
+    tags: [xrd, diffraction, parser]
+  -
+    # str (stable ID slug), e.g. "parse-xrd-patterns"
+    id: parse-quantumdesign-measurements
+    # str
+    title: Parse Quantum Design measurements
+    # str (what user wants to do), e.g. "Import and parse raw files"
+    user_intent: Import PPMS/MPMS transport and magnetometry outputs
+    # enum {simulations, measurements, synthesis, cross-domain, workflow, infrastructure}
+    domain_category: measurements
+    # str, e.g. "XRD", "DFT"
+    technique: quantum-design
+    # str, e.g. "beginner", "expert"
+    audience: intermediate
+    # enum {alpha, beta, stable, archived}
+    maturity: stable
+    # list[str]
+    tags: [ppms, mpms, transport, magnetometry]
+  -
+    # str (stable ID slug), e.g. "parse-xrd-patterns"
+    id: parse-transmission-spectra
+    # str
+    title: Parse transmission spectroscopy files
+    # str (what user wants to do), e.g. "Import and parse raw files"
+    user_intent: Import UV-Vis transmission measurement outputs
+    # enum {simulations, measurements, synthesis, cross-domain, workflow, infrastructure}
+    domain_category: measurements
+    # str, e.g. "XRD", "DFT"
+    technique: transmission-spectroscopy
+    # str, e.g. "beginner", "expert"
+    audience: intermediate
+    # enum {alpha, beta, stable, archived}
+    maturity: stable
+    # list[str]
+    tags: [transmission, uv-vis, spectroscopy]
+
+# Optional file format metadata enrichments.
+file_format_support:
+  -
+    # str (stable ID), e.g. "csv"
+    id: dat-qd-act
+    # str display label, e.g. ".csv"
+    label: .dat (QD ACT)
+    # str capability reference (links to capabilities[].id), e.g. "vasp_parser"
+    capability_id: qd_act_parser
+    # str producer/code family for ambiguous extensions, e.g. "vasp", "quantumespresso"
+    producer: quantum-design-act
+    # list[str] extensions including dot, e.g. [".csv", ".txt"]
+    extensions: [.dat]
+    # list[str], e.g. ["text/csv"]
+    mime_types: [text/plain, application/x-wine-extension-ini]
+    # str, e.g. "CIF", "NeXus"
+    standard: null
+    # str, instrument or context label
+    instrument_context: Quantum Design ACT
+    # str free text notes
+    notes: Disambiguated from other QD .dat formats.
+  -
+    # str (stable ID), e.g. "csv"
+    id: dat-qd-acms
+    # str display label, e.g. ".csv"
+    label: .dat (QD ACMS)
+    # str capability reference (links to capabilities[].id), e.g. "vasp_parser"
+    capability_id: qd_acms_parser
+    # str producer/code family for ambiguous extensions, e.g. "vasp", "quantumespresso"
+    producer: quantum-design-acms
+    # list[str] extensions including dot, e.g. [".csv", ".txt"]
+    extensions: [.dat]
+    # list[str], e.g. ["text/csv"]
+    mime_types: [text/plain, application/x-wine-extension-ini]
+    # str, e.g. "CIF", "NeXus"
+    standard: null
+    # str, instrument or context label
+    instrument_context: Quantum Design ACMS
+    # str free text notes
+    notes: Same extension as other QD parsers but different BYAPP signature.

--- a/.metadata/plugin-metadata.override-report.yaml
+++ b/.metadata/plugin-metadata.override-report.yaml
@@ -1,0 +1,4 @@
+summary:
+  overridden_field_count: 0
+  manual_precedence: true
+overridden_fields: []

--- a/.metadata/plugin-metadata.override-report.yaml
+++ b/.metadata/plugin-metadata.override-report.yaml
@@ -1,4 +1,85 @@
 summary:
-  overridden_field_count: 0
+  overridden_field_count: 1
   manual_precedence: true
-overridden_fields: []
+overridden_fields:
+- field: file_format_support
+  generated_value:
+  - id: xrdml
+    label: .xrdml
+    capability_id: xrd_parser
+    producer: xrd-parser
+    extensions:
+    - .xrdml
+    mime_types:
+    - text/.*|application/zip|application/octet-stream
+  - id: rasx
+    label: .rasx
+    capability_id: xrd_parser
+    producer: xrd-parser
+    extensions:
+    - .rasx
+    mime_types:
+    - text/.*|application/zip|application/octet-stream
+  - id: brml
+    label: .brml
+    capability_id: xrd_parser
+    producer: xrd-parser
+    extensions:
+    - .brml
+    mime_types:
+    - text/.*|application/zip|application/octet-stream
+  - id: raw
+    label: .raw
+    capability_id: xrd_parser
+    producer: xrd-parser
+    extensions:
+    - .raw
+    mime_types:
+    - text/.*|application/zip|application/octet-stream
+  - id: dat
+    label: .dat
+    capability_id: qd_eto_parser
+    producer: dataparser-for-qd-eto
+    extensions:
+    - .dat
+    mime_types:
+    - text/plain|application/x-wine-extension-ini
+  - id: seq
+    label: .seq
+    capability_id: qd_sequence_parser
+    producer: qdsequenceparser
+    extensions:
+    - .seq
+    mime_types:
+    - text/plain
+  - id: asc
+    label: .asc
+    capability_id: transmission_parser
+    producer: transmission-parser
+    extensions:
+    - .asc
+    mime_types:
+    - text/.*|application/zip
+  manual_value:
+  - id: dat-qd-act
+    label: .dat (QD ACT)
+    capability_id: qd_act_parser
+    producer: quantum-design-act
+    extensions:
+    - .dat
+    mime_types:
+    - text/plain
+    - application/x-wine-extension-ini
+    instrument_context: Quantum Design ACT
+    notes: Disambiguated from other QD .dat formats.
+  - id: dat-qd-acms
+    label: .dat (QD ACMS)
+    capability_id: qd_acms_parser
+    producer: quantum-design-acms
+    extensions:
+    - .dat
+    mime_types:
+    - text/plain
+    - application/x-wine-extension-ini
+    instrument_context: Quantum Design ACMS
+    notes: Same extension as other QD parsers but different BYAPP signature.

--- a/nomad_plugin_metadata.yaml
+++ b/nomad_plugin_metadata.yaml
@@ -249,62 +249,28 @@ supported_filetypes:
 - .seq
 - .asc
 file_format_support:
-- id: xrdml
-  label: .xrdml
-  capability_id: xrd_parser
-  producer: xrd-parser
-  extensions:
-  - .xrdml
-  mime_types:
-  - text/.*|application/zip|application/octet-stream
-- id: rasx
-  label: .rasx
-  capability_id: xrd_parser
-  producer: xrd-parser
-  extensions:
-  - .rasx
-  mime_types:
-  - text/.*|application/zip|application/octet-stream
-- id: brml
-  label: .brml
-  capability_id: xrd_parser
-  producer: xrd-parser
-  extensions:
-  - .brml
-  mime_types:
-  - text/.*|application/zip|application/octet-stream
-- id: raw
-  label: .raw
-  capability_id: xrd_parser
-  producer: xrd-parser
-  extensions:
-  - .raw
-  mime_types:
-  - text/.*|application/zip|application/octet-stream
-- id: dat
-  label: .dat
-  capability_id: qd_eto_parser
-  producer: dataparser-for-qd-eto
+- id: dat-qd-act
+  label: .dat (QD ACT)
+  capability_id: qd_act_parser
+  producer: quantum-design-act
   extensions:
   - .dat
   mime_types:
-  - text/plain|application/x-wine-extension-ini
-- id: seq
-  label: .seq
-  capability_id: qd_sequence_parser
-  producer: qdsequenceparser
+  - text/plain
+  - application/x-wine-extension-ini
+  instrument_context: Quantum Design ACT
+  notes: Disambiguated from other QD .dat formats.
+- id: dat-qd-acms
+  label: .dat (QD ACMS)
+  capability_id: qd_acms_parser
+  producer: quantum-design-acms
   extensions:
-  - .seq
+  - .dat
   mime_types:
   - text/plain
-- id: asc
-  label: .asc
-  capability_id: transmission_parser
-  producer: transmission-parser
-  extensions:
-  - .asc
-  mime_types:
-  - text/.*|application/zip
+  - application/x-wine-extension-ini
+  instrument_context: Quantum Design ACMS
+  notes: Same extension as other QD parsers but different BYAPP signature.
 schema_dependencies:
 - dependency_type: python_package
   package_name: nomad-lab
@@ -349,15 +315,15 @@ schema_dependencies:
 metadata_provenance:
 - source: pyproject
   extraction_method: deterministic
-  generated_at: '2026-03-19T14:39:01.416619+00:00'
+  generated_at: '2026-03-19T14:51:28.256431+00:00'
   generator_version: 0.1.0
 - source: plugin_entry_points
   extraction_method: deterministic
-  generated_at: '2026-03-19T14:39:01.416660+00:00'
+  generated_at: '2026-03-19T14:51:28.256467+00:00'
   generator_version: 0.1.0
 - source: citation_cff
   extraction_method: deterministic
-  generated_at: '2026-03-19T14:39:01.416676+00:00'
+  generated_at: '2026-03-19T14:51:28.256481+00:00'
   generator_version: 0.1.0
 stars: 15
 owner: FAIRmat-NFDI
@@ -365,3 +331,51 @@ owner_type: Organization
 created: '2023-09-06T10:00:22Z'
 last_updated: '2026-01-07T14:47:20Z'
 archived: false
+subject:
+- measurements
+- xrd
+- transport
+- magnetometry
+- spectroscopy
+maturity: stable
+repository_default_branch: main
+deployment:
+  on_central: false
+  on_example_oasis: true
+  on_pypi: true
+  pypi_package: nomad-measurements
+suggested_usages:
+- id: parse-xrd-raw-files
+  title: Parse XRD raw files
+  user_intent: Import powder XRD raw outputs into NOMAD
+  domain_category: measurements
+  technique: xrd
+  audience: intermediate
+  maturity: stable
+  tags:
+  - xrd
+  - diffraction
+  - parser
+- id: parse-quantumdesign-measurements
+  title: Parse Quantum Design measurements
+  user_intent: Import PPMS/MPMS transport and magnetometry outputs
+  domain_category: measurements
+  technique: quantum-design
+  audience: intermediate
+  maturity: stable
+  tags:
+  - ppms
+  - mpms
+  - transport
+  - magnetometry
+- id: parse-transmission-spectra
+  title: Parse transmission spectroscopy files
+  user_intent: Import UV-Vis transmission measurement outputs
+  domain_category: measurements
+  technique: transmission-spectroscopy
+  audience: intermediate
+  maturity: stable
+  tags:
+  - transmission
+  - uv-vis
+  - spectroscopy

--- a/nomad_plugin_metadata.yaml
+++ b/nomad_plugin_metadata.yaml
@@ -1,0 +1,367 @@
+id: nomad-measurements
+metadata_schema_version: 1.0.0
+name: nomad-measurements
+description: A plugin for NOMAD containing base sections for measurements.
+license: LICENSE
+upstream_repository: https://github.com/FAIRmat-NFDI/nomad-measurements
+documentation: https://fairmat-nfdi.github.io/nomad-measurements/
+homepage: https://github.com/FAIRmat-NFDI/nomad-measurements
+issue_tracker: https://github.com/FAIRmat-NFDI/nomad-measurements/issues
+maintainers:
+- name: FAIRmat
+  email: fairmat@physik.hu-berlin.de
+authors:
+- name: Andrea Albino
+- name: "Sebastian Br\xFCckner"
+- name: Sarthak Kapoor
+- name: "Jos\xE9 A. M\xE1rquez"
+- name: Rubel Mozumder
+- name: "Hampus N\xE4sstr\xF6m"
+entry_points:
+- id: nomad.plugin:general_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: general_schema
+  python_object: nomad_measurements:schema_entry_point
+  capability_type: schema
+- id: nomad.plugin:xrd_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: xrd_schema
+  python_object: nomad_measurements.xrd:schema_entry_point
+  capability_type: schema
+- id: nomad.plugin:xrd_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: xrd_parser
+  python_object: nomad_measurements.xrd:parser_entry_point
+  capability_type: parser
+- id: nomad.plugin:qd_eto_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_eto_schema
+  python_object: nomad_measurements.quantumdesign:eto_schema
+  capability_type: schema
+- id: nomad.plugin:qd_act_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_act_schema
+  python_object: nomad_measurements.quantumdesign:act_schema
+  capability_type: schema
+- id: nomad.plugin:qd_acms_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_acms_schema
+  python_object: nomad_measurements.quantumdesign:acms_schema
+  capability_type: schema
+- id: nomad.plugin:qd_mpms_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_mpms_schema
+  python_object: nomad_measurements.quantumdesign:mpms_schema
+  capability_type: schema
+- id: nomad.plugin:qd_resisitivity_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_resisitivity_schema
+  python_object: nomad_measurements.quantumdesign:resistivity_schema
+  capability_type: schema
+- id: nomad.plugin:qd_eto_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_eto_parser
+  python_object: nomad_measurements.quantumdesign:eto_parser
+  capability_type: parser
+- id: nomad.plugin:qd_act_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_act_parser
+  python_object: nomad_measurements.quantumdesign:act_parser
+  capability_type: parser
+- id: nomad.plugin:qd_acms_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_acms_parser
+  python_object: nomad_measurements.quantumdesign:acms_parser
+  capability_type: parser
+- id: nomad.plugin:qd_mpms_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_mpms_parser
+  python_object: nomad_measurements.quantumdesign:mpms_parser
+  capability_type: parser
+- id: nomad.plugin:qd_resistivity_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_resistivity_parser
+  python_object: nomad_measurements.quantumdesign:resistivity_parser
+  capability_type: parser
+- id: nomad.plugin:qd_sequence_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: qd_sequence_parser
+  python_object: nomad_measurements.quantumdesign:sequence_parser
+  capability_type: parser
+- id: nomad.plugin:transmission_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: transmission_schema
+  python_object: nomad_measurements.transmission:schema_entry_point
+  capability_type: schema
+- id: nomad.plugin:transmission_parser
+  entry_point_group: nomad.plugin
+  entry_point_name: transmission_parser
+  python_object: nomad_measurements.transmission:parser_entry_point
+  capability_type: parser
+- id: nomad.plugin:mapping_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: mapping_schema
+  python_object: nomad_measurements.mapping:schema_entry_point
+  capability_type: schema
+capabilities:
+- id: general_schema
+  capability_type: schema
+  title: General Schema
+  summary: Schema package containing basic classes used around in the plugin.
+- id: xrd_schema
+  capability_type: schema
+  title: XRD Schema
+  summary: Schema for XRD FAIR data.
+- id: xrd_parser
+  capability_type: parser
+  title: XRD Parser
+  summary: Parser for several kinds of raw files from XRD measurements.
+  parser_details:
+    parser_name: XRD Parser
+    parser_level: 0
+    mainfile_name_re: ^.*\.xrdml$|^.*\.rasx$|^.*\.brml$|^.*\.raw$
+    mainfile_mime_re: text/.*|application/zip|application/octet-stream
+    mainfile_alternative: false
+- id: qd_eto_schema
+  capability_type: schema
+  title: PQD ETO Schema
+  summary: Schema for QD measurements done by the ETO option.
+- id: qd_act_schema
+  capability_type: schema
+  title: QD ACT Schema
+  summary: Schema for QD measurements done by the ACT option.
+- id: qd_acms_schema
+  capability_type: schema
+  title: QD ACMS Schema
+  summary: Schema for QD measurements done by the ACMS option.
+- id: qd_mpms_schema
+  capability_type: schema
+  title: QD MPMS Schema
+  summary: Schema for QD measurements done by the MPMS option.
+- id: qd_resisitivity_schema
+  capability_type: schema
+  title: QD Resistivity Schema
+  summary: Schema for QD measurements done by the Resistivity option.
+- id: qd_eto_parser
+  capability_type: parser
+  title: DataParser for QD ETO
+  summary: "Parser for QD data files created by the ETO option.\n        Parses files\
+    \ containing the 'BYAPP, Electrical Transport Option' line and\n        extracts\
+    \ resistivities, temperatures, fields, and other relevant data. "
+  parser_details:
+    parser_name: DataParser for QD ETO
+    parser_level: 0
+    mainfile_name_re: .+\.dat
+    mainfile_contents_re: BYAPP, Electrical Transport Option
+    mainfile_mime_re: text/plain|application/x-wine-extension-ini
+    mainfile_alternative: false
+- id: qd_act_parser
+  capability_type: parser
+  title: DataParser for QD ACT
+  summary: "Parser for QD data files created by the ACT option.\n        Parses files\
+    \ containing the 'BYAPP, ACTRANSPORT' (Alternating current\n        transport)\
+    \ line and extracts resistivities, temperatures, fields, and other\n        relevant\
+    \ data. "
+  parser_details:
+    parser_name: DataParser for QD ACT
+    parser_level: 0
+    mainfile_name_re: .+\.dat
+    mainfile_contents_re: BYAPP,\s*ACTRANSPORT
+    mainfile_mime_re: text/plain|application/x-wine-extension-ini
+    mainfile_alternative: false
+- id: qd_acms_parser
+  capability_type: parser
+  title: DataParser for QD ACMS
+  summary: 'Parser for QD data files created by the ACMS option.         Parses files
+    containing the ''BYAPP, ACMS'' (Alternating current magnetic        susceptibility)
+    line and extracts resistivities, temperatures, fields, and         other relevant
+    data. '
+  parser_details:
+    parser_name: DataParser for QD ACMS
+    parser_level: 0
+    mainfile_name_re: .+\.dat
+    mainfile_contents_re: BYAPP,\s*ACMS
+    mainfile_mime_re: text/plain|application/x-wine-extension-ini
+    mainfile_alternative: false
+- id: qd_mpms_parser
+  capability_type: parser
+  title: DataParser for QD MPMS
+  summary: "Parser for QD data files created by the MPMS option.\n        Parses files\
+    \ containing the 'BYAPP, MPMS' (Magnetic property measurement\n        system)\
+    \ line and extracts temperatures, fields, and other relevant data. "
+  parser_details:
+    parser_name: DataParser for QD MPMS
+    parser_level: 0
+    mainfile_name_re: .+\.dat
+    mainfile_contents_re: BYAPP,\s*MPMS
+    mainfile_mime_re: text/plain|application/x-wine-extension-ini
+    mainfile_alternative: false
+- id: qd_resistivity_parser
+  capability_type: parser
+  title: DataParser for QD Resistivity
+  summary: "Parser for QD data files created by the Resistivity option.\n        Parses\
+    \ files containing the 'BYAPP, Resistivity' line and extracts\n        resistivities,\
+    \ temperatures, fields, and other relevant data. "
+  parser_details:
+    parser_name: DataParser for QD Resistivity
+    parser_level: 0
+    mainfile_name_re: .+\.dat
+    mainfile_contents_re: BYAPP,\s*Resistivity
+    mainfile_mime_re: text/plain|application/x-wine-extension-ini
+    mainfile_alternative: false
+- id: qd_sequence_parser
+  capability_type: parser
+  title: QDSequenceParser
+  summary: Parser for QD sequence files.
+  parser_details:
+    parser_name: QDSequenceParser
+    parser_level: 0
+    mainfile_name_re: .+\.seq
+    mainfile_mime_re: text/plain
+    mainfile_alternative: false
+- id: transmission_schema
+  capability_type: schema
+  title: Transmission Schema
+  summary: Schema for data from Transmission Spectrophotometry.
+- id: transmission_parser
+  capability_type: parser
+  title: Transmission Parser
+  summary: "\n    Parser for data from Transmission Spectrophotometry measurements.\
+    \ Currently\n    supports `.asc` files generated by Perkin Elmer UV WinLab software.\n\
+    \    "
+  parser_details:
+    parser_name: Transmission Parser
+    parser_level: 0
+    mainfile_name_re: ^.*\.asc$
+    mainfile_contents_re: ^PE UV
+    mainfile_mime_re: text/.*|application/zip
+    mainfile_alternative: false
+- id: mapping_schema
+  capability_type: schema
+  title: Mapping Schema
+  summary: Schema package containing schemas for mapping measurements.
+supported_filetypes:
+- .xrdml
+- .rasx
+- .brml
+- .raw
+- .dat
+- .seq
+- .asc
+file_format_support:
+- id: xrdml
+  label: .xrdml
+  capability_id: xrd_parser
+  producer: xrd-parser
+  extensions:
+  - .xrdml
+  mime_types:
+  - text/.*|application/zip|application/octet-stream
+- id: rasx
+  label: .rasx
+  capability_id: xrd_parser
+  producer: xrd-parser
+  extensions:
+  - .rasx
+  mime_types:
+  - text/.*|application/zip|application/octet-stream
+- id: brml
+  label: .brml
+  capability_id: xrd_parser
+  producer: xrd-parser
+  extensions:
+  - .brml
+  mime_types:
+  - text/.*|application/zip|application/octet-stream
+- id: raw
+  label: .raw
+  capability_id: xrd_parser
+  producer: xrd-parser
+  extensions:
+  - .raw
+  mime_types:
+  - text/.*|application/zip|application/octet-stream
+- id: dat
+  label: .dat
+  capability_id: qd_eto_parser
+  producer: dataparser-for-qd-eto
+  extensions:
+  - .dat
+  mime_types:
+  - text/plain|application/x-wine-extension-ini
+- id: seq
+  label: .seq
+  capability_id: qd_sequence_parser
+  producer: qdsequenceparser
+  extensions:
+  - .seq
+  mime_types:
+  - text/plain
+- id: asc
+  label: .asc
+  capability_id: transmission_parser
+  producer: transmission-parser
+  extensions:
+  - .asc
+  mime_types:
+  - text/.*|application/zip
+schema_dependencies:
+- dependency_type: python_package
+  package_name: nomad-lab
+  version_range: '>=1.3.16'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: fairmat-readers-xrd
+  version_range: '>=0.0.8'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: fairmat-readers-transmission
+  version_range: '>=0.0.2'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: pynxtools
+  version_range: '>=0.10.0'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pytest
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: ruff
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: structlog
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: python-logstash
+  version_range: '>=0.4.6'
+  optional: true
+  purpose: optional
+metadata_provenance:
+- source: pyproject
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:39:01.416619+00:00'
+  generator_version: 0.1.0
+- source: plugin_entry_points
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:39:01.416660+00:00'
+  generator_version: 0.1.0
+- source: citation_cff
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:39:01.416676+00:00'
+  generator_version: 0.1.0
+stars: 15
+owner: FAIRmat-NFDI
+owner_type: Organization
+created: '2023-09-06T10:00:22Z'
+last_updated: '2026-01-07T14:47:20Z'
+archived: false


### PR DESCRIPTION
## Summary

This PR adds the first metadata extraction for `nomad-simulation-parsers` using the `nomad-plugin-metadata` pipeline.

## What to review

Please review **`nomad_plugin_metadata.yaml`**.  
This is the canonical, merged file intended for querying/registry usage.

## How files work

- `.metadata/nomad_plugin_metadata.auto.yaml`  
  Machine-generated metadata from package/plugin introspection.
- `.metadata/nomad_plugin_metadata.manual.yaml`  
  Maintainer-owned manual curation/overrides (not machine-overwritten).
- `nomad_plugin_metadata.yaml`  
  Final merged output (auto + manual; manual non-empty values take precedence).
- `.metadata/plugin-metadata.override-report.yaml`  
  Report of conflicts where manual overrides auto.

## Goal of this PR

Initial extraction pass for developer feedback before broader rollout:
- verify extracted parser/file-format metadata
- identify missing/incorrect fields
- align expected manual curation scope

## References

- `nomad-plugins-metadata`: https://github.com/FAIRmat-NFDI/nomad-plugins-metadata, https://fairmat-nfdi.github.io/nomad-plugins-metadata/reference/schema_reference.html#full-schema-shaped-yaml-template
- `datatractor`: https://github.com/datatractor
