### PR TITLE
Fix CI failure for XRD nexus 

### DIFF
--- a/src/nomad_measurements/utils.py
+++ b/src/nomad_measurements/utils.py
@@ -526,16 +526,16 @@ class HDF5Handler:
             else:
                 data = arch_path  # default value
 
-            dataset = Dataset(data=data)
+            units = None
+            if isinstance(data, pint.Quantity):
+                dataset = Dataset(data=data.magnitude)
+                units = data.units
+            else:
+                dataset = Dataset(data=data)
 
-            if (
-                isinstance(data, pint.Quantity)
-                and str(data.units) != 'dimensionless'
-                and str(data.units)
-            ):
-                attr_tmp = {nx_path: dict(units=str(data.units))}
-                attr_dict |= attr_tmp
-                dataset.data = data.magnitude
+            if units:
+                # add units as attributes
+                attr_dict |= {nx_path: dict(units=str(units))}
 
             l_part, r_part = nx_path.rsplit('/', 1)
             if r_part.startswith('@'):


### PR DESCRIPTION
Fixes the failing CI for `pytest`.

### Error source
In `_populate_nx_dataset_and_attribute` method, `ratio_k_alphatwo_k_alphaone` Quantity was being added as is to the nexus template, rather than adding its magnitude. This lead to unexpected failure in the `pynxtools.dataconverter.writer.Writer` where the scalar Quantity was judged as a non-scalar one. 

This was the result of incorrect handling `dimensionless` quantities. This PR refactors the assignment of quantities and treats `dimensionless` just like any other units.

**Note:** Eventually, the dimensionless units are not added to the final nexus files, but that is taken care in `_write_nx_file` method. 